### PR TITLE
fix: Updated uint cast to not truncate

### DIFF
--- a/contracts/tokenbridge/ethereum/ICustomToken.sol
+++ b/contracts/tokenbridge/ethereum/ICustomToken.sol
@@ -20,7 +20,7 @@
 pragma solidity >=0.6.9 <0.9.0;
 
 interface ArbitrumEnabledToken {
-    /// @notice should return `0xa4b1` if token is enabled for arbitrum gateways
+    /// @notice should return `0xa4` if token is enabled for arbitrum gateways
     function isArbitrumEnabled() external view returns (uint8);
 }
 

--- a/contracts/tokenbridge/ethereum/ICustomToken.sol
+++ b/contracts/tokenbridge/ethereum/ICustomToken.sol
@@ -20,7 +20,7 @@
 pragma solidity >=0.6.9 <0.9.0;
 
 interface ArbitrumEnabledToken {
-    /// @notice should return `0xa4` if token is enabled for arbitrum gateways
+    /// @notice should return `0xb1` if token is enabled for arbitrum gateways
     function isArbitrumEnabled() external view returns (uint8);
 }
 

--- a/contracts/tokenbridge/ethereum/gateway/L1CustomGateway.sol
+++ b/contracts/tokenbridge/ethereum/gateway/L1CustomGateway.sol
@@ -151,7 +151,7 @@ contract L1CustomGateway is L1ArbitrumExtendedGateway, ICustomGateway {
         address _creditBackAddress
     ) public payable returns (uint256) {
         require(
-            ArbitrumEnabledToken(msg.sender).isArbitrumEnabled() == uint8(0xa4b1),
+            ArbitrumEnabledToken(msg.sender).isArbitrumEnabled() == uint8(0xa4),
             "NOT_ARB_ENABLED"
         );
 

--- a/contracts/tokenbridge/ethereum/gateway/L1CustomGateway.sol
+++ b/contracts/tokenbridge/ethereum/gateway/L1CustomGateway.sol
@@ -151,7 +151,7 @@ contract L1CustomGateway is L1ArbitrumExtendedGateway, ICustomGateway {
         address _creditBackAddress
     ) public payable returns (uint256) {
         require(
-            ArbitrumEnabledToken(msg.sender).isArbitrumEnabled() == uint8(0xa4),
+            ArbitrumEnabledToken(msg.sender).isArbitrumEnabled() == uint8(0xb1),
             "NOT_ARB_ENABLED"
         );
 

--- a/contracts/tokenbridge/ethereum/gateway/L1GatewayRouter.sol
+++ b/contracts/tokenbridge/ethereum/gateway/L1GatewayRouter.sol
@@ -185,7 +185,7 @@ contract L1GatewayRouter is
         address _creditBackAddress
     ) public payable override returns (uint256) {
         require(
-            ArbitrumEnabledToken(msg.sender).isArbitrumEnabled() == uint8(0xa4),
+            ArbitrumEnabledToken(msg.sender).isArbitrumEnabled() == uint8(0xb1),
             "NOT_ARB_ENABLED"
         );
         require(_gateway.isContract(), "NOT_TO_CONTRACT");

--- a/contracts/tokenbridge/ethereum/gateway/L1GatewayRouter.sol
+++ b/contracts/tokenbridge/ethereum/gateway/L1GatewayRouter.sol
@@ -185,7 +185,7 @@ contract L1GatewayRouter is
         address _creditBackAddress
     ) public payable override returns (uint256) {
         require(
-            ArbitrumEnabledToken(msg.sender).isArbitrumEnabled() == uint8(0xa4b1),
+            ArbitrumEnabledToken(msg.sender).isArbitrumEnabled() == uint8(0xa4),
             "NOT_ARB_ENABLED"
         );
         require(_gateway.isContract(), "NOT_TO_CONTRACT");

--- a/contracts/tokenbridge/test/TestCustomTokenL1.sol
+++ b/contracts/tokenbridge/test/TestCustomTokenL1.sol
@@ -66,7 +66,7 @@ contract TestCustomTokenL1 is aeERC20, ICustomToken {
     /// @dev we only set shouldRegisterGateway to true when in `registerTokenOnL2`
     function isArbitrumEnabled() external view override returns (uint8) {
         require(shouldRegisterGateway, "NOT_EXPECTED_CALL");
-        return uint8(0xa4b1);
+        return uint8(0xa4);
     }
 
     function registerTokenOnL2(

--- a/contracts/tokenbridge/test/TestCustomTokenL1.sol
+++ b/contracts/tokenbridge/test/TestCustomTokenL1.sol
@@ -66,7 +66,7 @@ contract TestCustomTokenL1 is aeERC20, ICustomToken {
     /// @dev we only set shouldRegisterGateway to true when in `registerTokenOnL2`
     function isArbitrumEnabled() external view override returns (uint8) {
         require(shouldRegisterGateway, "NOT_EXPECTED_CALL");
-        return uint8(0xa4);
+        return uint8(0xb1);
     }
 
     function registerTokenOnL2(


### PR DESCRIPTION
We used to truncate a magic value for `isArbitrumEnabled`, however this causes compile time errors and warnings on newer solidity versions