### PR TITLE
feat: remove transfer check validation

### DIFF
--- a/_deployments/1_42170_queued-updates.json
+++ b/_deployments/1_42170_queued-updates.json
@@ -1,9 +1,8 @@
 {
-    "L1GatewayRouter": {
-      "address": "0x52595021fA01B3E14EC6C88953AFc8E35dFf423c",
-      "deployTxn": "0x2a6dd507b21d4257c8afd00f2590cb5765e29eb371d2b6b2f9a173328b9f2e53",
-      "arbitrumCommitHash": "162e913442e766b3bcc17e3e62886477313325ac",
-      "buildInfo": ""
-    }
+  "L1GatewayRouter": {
+    "address": "0x52595021fA01B3E14EC6C88953AFc8E35dFf423c",
+    "deployTxn": "0x2a6dd507b21d4257c8afd00f2590cb5765e29eb371d2b6b2f9a173328b9f2e53",
+    "arbitrumCommitHash": "162e913442e766b3bcc17e3e62886477313325ac",
+    "buildInfo": ""
   }
-  
+}

--- a/_deployments/1_42170_queued-updates.json
+++ b/_deployments/1_42170_queued-updates.json
@@ -1,1 +1,9 @@
-{}
+{
+    "L1GatewayRouter": {
+      "address": "0x52595021fA01B3E14EC6C88953AFc8E35dFf423c",
+      "deployTxn": "0x2a6dd507b21d4257c8afd00f2590cb5765e29eb371d2b6b2f9a173328b9f2e53",
+      "arbitrumCommitHash": "162e913442e766b3bcc17e3e62886477313325ac",
+      "buildInfo": ""
+    }
+  }
+  

--- a/_deployments/1_queued-updates.json
+++ b/_deployments/1_queued-updates.json
@@ -1,1 +1,8 @@
-{}
+{
+  "L1GatewayRouter": {
+    "address": "0x52595021fA01B3E14EC6C88953AFc8E35dFf423c",
+    "deployTxn": "0x2a6dd507b21d4257c8afd00f2590cb5765e29eb371d2b6b2f9a173328b9f2e53",
+    "arbitrumCommitHash": "162e913442e766b3bcc17e3e62886477313325ac",
+    "buildInfo": ""
+  }
+}

--- a/_deployments/4_queued-updates.json
+++ b/_deployments/4_queued-updates.json
@@ -1,1 +1,8 @@
-{}
+{
+  "L1GatewayRouter": {
+    "address": "0xba4F913CEb90ff1a0A8ccf7bd06B807B92B2E34e",
+    "deployTxn": "0x81a1aec762bdc2e53f72b7cec2b96cc78757b212da759ad0c6670934a2e65d3a",
+    "arbitrumCommitHash": "162e913442e766b3bcc17e3e62886477313325ac",
+    "buildInfo": ""
+  }
+}

--- a/_deployments/5_queued-updates.json
+++ b/_deployments/5_queued-updates.json
@@ -1,1 +1,8 @@
-{}
+{
+  "L1GatewayRouter": {
+    "address": "0xd828280182641F2d9B0cfe0116eaebCF7eEe94E1",
+    "deployTxn": "0x4b4781024c3cf02c4146d599741b5d26c8800b8361db660384d401a76eb3e35c",
+    "arbitrumCommitHash": "162e913442e766b3bcc17e3e62886477313325ac",
+    "buildInfo": ""
+  }
+}

--- a/contracts/tokenbridge/ethereum/gateway/L1GatewayRouter.sol
+++ b/contracts/tokenbridge/ethereum/gateway/L1GatewayRouter.sol
@@ -226,24 +226,6 @@ contract L1GatewayRouter is
             _setGateways(_token, _gateway, _maxGas, _gasPriceBid, _maxSubmissionCost, msg.sender);
     }
 
-    function _outboundTransferChecks(
-        uint256 _maxGas,
-        uint256 _gasPriceBid,
-        bytes calldata _data
-    ) internal view {
-        // when sending a L1 to L2 transaction, we expect the user to send
-        // eth in flight in order to pay for L2 gas costs
-        // this check prevents users from misconfiguring the msg.value
-
-        // _data is (uint256, bytes) encoded, but we don't need the bytes
-        uint256 _maxSubmissionCost = abi.decode(_data, (uint256));
-
-        // here we don't use SafeMath since this validation is to prevent users
-        // from shooting themselves on the foot.
-        require(_maxSubmissionCost != 0, "NO_SUBMISSION_COST");
-        require(msg.value == _maxSubmissionCost + (_maxGas * _gasPriceBid), "WRONG_ETH_VALUE");
-    }
-
     function outboundTransfer(
         address _token,
         address _to,
@@ -252,8 +234,6 @@ contract L1GatewayRouter is
         uint256 _gasPriceBid,
         bytes calldata _data
     ) public payable override(GatewayRouter, ITokenGateway) returns (bytes memory) {
-        _outboundTransferChecks(_maxGas, _gasPriceBid, _data);
-
         return super.outboundTransfer(_token, _to, _amount, _maxGas, _gasPriceBid, _data);
     }
 


### PR DESCRIPTION
The `outboundTransferChecks` validation step was introduced before the L1 inbox provided validation on the user's retryable ticket value.

The current `require` statement does not allow for users to cleanly deposit extra excess eth without having to change the gas parameters. 
The check could be changed to
```solidity
require(msg.value >= ... )
```
Which then becomes the same as the check the Inbox now currently does by default in https://github.com/OffchainLabs/nitro/blob/c191708c7847bf9e92c3c0a5263d31e4876d9e18/contracts/src/bridge/Inbox.sol#L413