### PR TITLE
ci: make sure no .only in test file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
     working_directory: ~/token-bridge-contracts
     steps:
       - checkout
+      - run: fgrep .only -R test/ && exit 1
       - run: |
           yarn install
           yarn build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
     working_directory: ~/token-bridge-contracts
     steps:
       - checkout
-      - run: fgrep .only -R test/ && exit 1
+      - run: fgrep .only -R test/ && exit 1 || exit 0
       - run: |
           yarn install
           yarn build

--- a/test/wethBridge.l1.ts
+++ b/test/wethBridge.l1.ts
@@ -358,7 +358,7 @@ describe('Bridge peripherals layer 1', () => {
     expect(await testBridge.supportsInterface('0xffffffff')).is.false
   })
 
-  it('should support outboundTransferCustomRefund interface', async function () {
+  it.only('should support outboundTransferCustomRefund interface', async function () {
     // 4fb1a07b  =>  outboundTransferCustomRefund(address,address,address,uint256,uint256,uint256,bytes)
     expect(await testBridge.supportsInterface('0x4fb1a07b')).is.true
   })

--- a/test/wethBridge.l1.ts
+++ b/test/wethBridge.l1.ts
@@ -358,7 +358,7 @@ describe('Bridge peripherals layer 1', () => {
     expect(await testBridge.supportsInterface('0xffffffff')).is.false
   })
 
-  it.only('should support outboundTransferCustomRefund interface', async function () {
+  it('should support outboundTransferCustomRefund interface', async function () {
     // 4fb1a07b  =>  outboundTransferCustomRefund(address,address,address,uint256,uint256,uint256,bytes)
     expect(await testBridge.supportsInterface('0x4fb1a07b')).is.true
   })


### PR DESCRIPTION
Simple hack to make sure we does not accidentally slipped `.only` to chai tests