### PR TITLE
fix: weth gateway exitnum issue

### DIFF
--- a/_deployments/1_42170_current_deployment.json
+++ b/_deployments/1_42170_current_deployment.json
@@ -24,9 +24,9 @@
     },
     "L1WethGateway": {
       "proxyAddress": "0xE4E2121b479017955Be0b175305B35f312330BaE",
-      "implAddress": "0x6299838C8254b59213eb56d158ebe562D23c4936",
-      "implDeploymentTxn": "0xc908d4f902b021a28618f8828e988fe4a25a676c4aab3414b25e783a62e17ba2",
-      "implArbitrumCommitHash": "265b5ef6a68f4e6c5d891d61b4c733634e49ac74",
+      "implAddress": "0x4B8e9b3F253E68837bf719997B1eeB9E8f1960e2",
+      "implDeploymentTxn": "0xab2fe7d6a85987ba63986267209e1a7b4b1347c6075230f23c8e6d18aaa1a6b3",
+      "implArbitrumCommitHash": "dce646c6890ab9c7c91c7d2ec70b4d83fa359a76",
       "implBuildInfo": ""
     }
   }

--- a/_deployments/1_current_deployment.json
+++ b/_deployments/1_current_deployment.json
@@ -24,9 +24,9 @@
     },
     "L1WethGateway": {
       "proxyAddress": "0xd92023E9d9911199a6711321D1277285e6d4e2db",
-      "implAddress": "0x6299838C8254b59213eb56d158ebe562D23c4936",
-      "implDeploymentTxn": "0xc908d4f902b021a28618f8828e988fe4a25a676c4aab3414b25e783a62e17ba2",
-      "implArbitrumCommitHash": "265b5ef6a68f4e6c5d891d61b4c733634e49ac74",
+      "implAddress": "0x4B8e9b3F253E68837bf719997B1eeB9E8f1960e2",
+      "implDeploymentTxn": "0xab2fe7d6a85987ba63986267209e1a7b4b1347c6075230f23c8e6d18aaa1a6b3",
+      "implArbitrumCommitHash": "dce646c6890ab9c7c91c7d2ec70b4d83fa359a76",
       "implBuildInfo": ""
     }
   }

--- a/_deployments/42161_current_deployment.json
+++ b/_deployments/42161_current_deployment.json
@@ -24,9 +24,9 @@
     },
     "L2WethGateway": {
       "proxyAddress": "0x6c411aD3E74De3E7Bd422b94A27770f5B86C623B",
-      "implAddress": "0xB642058A41D414D9De3F36D14051623e557f1052",
-      "implDeploymentTxn": "0x97f65d6e95d885fbf61e4824bbc59a365bb97ce8719265a09d1398b03347bc8b",
-      "implArbitrumCommitHash": "265b5ef6a68f4e6c5d891d61b4c733634e49ac74",
+      "implAddress": "0x806421D09cDb253aa9d128a658e60c0B95eFFA01",
+      "implDeploymentTxn": "0xb52586177829d7cb06ca5204994eb63e3ee8245ef8a331e5dc466cba9aa9e35d",
+      "implArbitrumCommitHash": "dce646c6890ab9c7c91c7d2ec70b4d83fa359a76",
       "implBuildInfo": ""
     },
     "StandardArbERC20": {

--- a/_deployments/42170_current_deployment.json
+++ b/_deployments/42170_current_deployment.json
@@ -24,9 +24,9 @@
     },
     "L2WethGateway": {
       "proxyAddress": "0x7626841cB6113412F9c88D3ADC720C9FAC88D9eD",
-      "implAddress": "0x190C993Db842097df8b8d71c910f1802df0724C3",
-      "implDeploymentTxn": "0x510b16690e35cd4490211c1b7f11762f2e47c33236076883d54d8c153df79855",
-      "implArbitrumCommitHash": "265b5ef6a68f4e6c5d891d61b4c733634e49ac74",
+      "implAddress": "0xbe04Ab2728c924D678f9FC833E379688c6eFA317",
+      "implDeploymentTxn": "0x99333784813d8bcfc7ccc34b7cf258deccec9d160afce25c89a9faf0a1a19a92",
+      "implArbitrumCommitHash": "dce646c6890ab9c7c91c7d2ec70b4d83fa359a76",
       "implBuildInfo": ""
     },
     "StandardArbERC20": {

--- a/contracts/tokenbridge/arbitrum/gateway/L2WethGateway.sol
+++ b/contracts/tokenbridge/arbitrum/gateway/L2WethGateway.sol
@@ -91,6 +91,8 @@ contract L2WethGateway is L2ArbitrumGateway {
         uint256 _tokenAmount,
         bytes memory _outboundCalldata
     ) internal override returns (uint256) {
+        // exitNum incremented after being included in _outboundCalldata
+        exitNum++;
         return
             sendTxToL1(
                 // we send the amount of weth withdrawn as callvalue to the L1 gateway

--- a/contracts/tokenbridge/arbitrum/gateway/L2WethGateway.sol
+++ b/contracts/tokenbridge/arbitrum/gateway/L2WethGateway.sol
@@ -40,10 +40,6 @@ contract L2WethGateway is L2ArbitrumGateway {
         require(_l2Weth != address(0), "INVALID_L2WETH");
         l1Weth = _l1Weth;
         l2Weth = _l2Weth;
-        // we skip the first 2 exit numbers becuase a previous version of this contract had exitNum
-        // stuck at 0/1 which we have to prevent those exit being traded by reverting with INVALID_EXIT_NUM in L1WethGateway 
-        // starting exitNum at 2 will prevent any new deployment triggering that revert
-        exitNum = 2;
     }
 
     /**

--- a/contracts/tokenbridge/arbitrum/gateway/L2WethGateway.sol
+++ b/contracts/tokenbridge/arbitrum/gateway/L2WethGateway.sol
@@ -40,6 +40,10 @@ contract L2WethGateway is L2ArbitrumGateway {
         require(_l2Weth != address(0), "INVALID_L2WETH");
         l1Weth = _l1Weth;
         l2Weth = _l2Weth;
+        // we skip the first 2 exit numbers becuase a previous version of this contract had exitNum
+        // stuck at 1 which we have to prevent those exit being traded by reverting with INVALID_EXIT_NUM in L1WethGateway 
+        // starting exitNum at 2 will prevent any new deployment triggering that revert
+        exitNum = 2;
     }
 
     /**

--- a/contracts/tokenbridge/arbitrum/gateway/L2WethGateway.sol
+++ b/contracts/tokenbridge/arbitrum/gateway/L2WethGateway.sol
@@ -41,7 +41,7 @@ contract L2WethGateway is L2ArbitrumGateway {
         l1Weth = _l1Weth;
         l2Weth = _l2Weth;
         // we skip the first 2 exit numbers becuase a previous version of this contract had exitNum
-        // stuck at 1 which we have to prevent those exit being traded by reverting with INVALID_EXIT_NUM in L1WethGateway 
+        // stuck at 0/1 which we have to prevent those exit being traded by reverting with INVALID_EXIT_NUM in L1WethGateway 
         // starting exitNum at 2 will prevent any new deployment triggering that revert
         exitNum = 2;
     }

--- a/contracts/tokenbridge/ethereum/gateway/L1ArbitrumExtendedGateway.sol
+++ b/contracts/tokenbridge/ethereum/gateway/L1ArbitrumExtendedGateway.sol
@@ -122,7 +122,7 @@ abstract contract L1ArbitrumExtendedGateway is L1ArbitrumGateway {
         address _initialDestination,
         address _newDestination,
         bytes memory _newData
-    ) internal {
+    ) internal virtual {
         bytes32 withdrawData = encodeWithdrawal(_exitNum, _initialDestination);
         redirectedExits[withdrawData] = ExitData(true, _newDestination, _newData);
     }

--- a/contracts/tokenbridge/ethereum/gateway/L1WethGateway.sol
+++ b/contracts/tokenbridge/ethereum/gateway/L1WethGateway.sol
@@ -118,8 +118,7 @@ contract L1WethGateway is L1ArbitrumExtendedGateway {
         address _newDestination,
         bytes memory _newData
     ) internal override {
-        require(_exitNum > 1, "INVALID_EXIT_NUM");
-        super.setRedirectedExit(_exitNum, _initialDestination, _newDestination, _newData);
+        revert("TRADABLE_EXIT_TEMP_DISABLED");
     }
 
     receive() external payable {}

--- a/contracts/tokenbridge/ethereum/gateway/L1WethGateway.sol
+++ b/contracts/tokenbridge/ethereum/gateway/L1WethGateway.sol
@@ -46,7 +46,7 @@ contract L1WethGateway is L1ArbitrumExtendedGateway {
         // we skip the first 2 exit numbers becuase a previous version of this contract had exitNum
         // stuck at 1 which we have to prevent those exit being traded by reverting with INVALID_EXIT_NUM
         // starting exitNum at 2 will prevent any new deployment triggering that revert
-        exitNum = 2;
+        _exitNum = 2;
     }
 
     function createOutboundTxCustomRefund(

--- a/contracts/tokenbridge/ethereum/gateway/L1WethGateway.sol
+++ b/contracts/tokenbridge/ethereum/gateway/L1WethGateway.sol
@@ -110,7 +110,7 @@ contract L1WethGateway is L1ArbitrumExtendedGateway {
     }
 
     /**
-     * @notice  this will revert with exitNum <= 1 to mitigate a known issue causing multiple exits with exitNum 0 and 1
+     * @notice  Temporary disable the ability to trade exits
      */
     function setRedirectedExit(
         uint256 _exitNum,

--- a/contracts/tokenbridge/ethereum/gateway/L1WethGateway.sol
+++ b/contracts/tokenbridge/ethereum/gateway/L1WethGateway.sol
@@ -119,8 +119,7 @@ contract L1WethGateway is L1ArbitrumExtendedGateway {
         bytes memory _newData
     ) internal override {
         require(_exitNum > 1, "INVALID_EXIT_NUM");
-        bytes32 withdrawData = encodeWithdrawal(_exitNum, _initialDestination);
-        redirectedExits[withdrawData] = ExitData(true, _newDestination, _newData);
+        super.setRedirectedExit(_exitNum, _initialDestination, _newDestination, _newData);
     }
 
     receive() external payable {}

--- a/contracts/tokenbridge/ethereum/gateway/L1WethGateway.sol
+++ b/contracts/tokenbridge/ethereum/gateway/L1WethGateway.sol
@@ -32,13 +32,13 @@ contract L1WethGateway is L1ArbitrumExtendedGateway {
     address public l2Weth;
 
     function initialize(
-        address _l1Counterpart,
+        address _l2Counterpart,
         address _l1Router,
         address _inbox,
         address _l1Weth,
         address _l2Weth
     ) public {
-        L1ArbitrumGateway._initialize(_l1Counterpart, _l1Router, _inbox);
+        L1ArbitrumGateway._initialize(_l2Counterpart, _l1Router, _inbox);
         require(_l1Weth != address(0), "INVALID_L1WETH");
         require(_l2Weth != address(0), "INVALID_L2WETH");
         l1Weth = _l1Weth;

--- a/contracts/tokenbridge/ethereum/gateway/L1WethGateway.sol
+++ b/contracts/tokenbridge/ethereum/gateway/L1WethGateway.sol
@@ -109,5 +109,19 @@ contract L1WethGateway is L1ArbitrumExtendedGateway {
         return l2Weth;
     }
 
+    /**
+     * @notice  this will revert with exitNum <= 1 to mitigate a known issue
+     */
+    function setRedirectedExit(
+        uint256 _exitNum,
+        address _initialDestination,
+        address _newDestination,
+        bytes memory _newData
+    ) internal override {
+        require(_exitNum > 1, "INVALID_EXIT_NUM");
+        bytes32 withdrawData = encodeWithdrawal(_exitNum, _initialDestination);
+        redirectedExits[withdrawData] = ExitData(true, _newDestination, _newData);
+    }
+
     receive() external payable {}
 }

--- a/contracts/tokenbridge/ethereum/gateway/L1WethGateway.sol
+++ b/contracts/tokenbridge/ethereum/gateway/L1WethGateway.sol
@@ -43,10 +43,6 @@ contract L1WethGateway is L1ArbitrumExtendedGateway {
         require(_l2Weth != address(0), "INVALID_L2WETH");
         l1Weth = _l1Weth;
         l2Weth = _l2Weth;
-        // we skip the first 2 exit numbers becuase a previous version of this contract had exitNum
-        // stuck at 1 which we have to prevent those exit being traded by reverting with INVALID_EXIT_NUM
-        // starting exitNum at 2 will prevent any new deployment triggering that revert
-        _exitNum = 2;
     }
 
     function createOutboundTxCustomRefund(

--- a/contracts/tokenbridge/ethereum/gateway/L1WethGateway.sol
+++ b/contracts/tokenbridge/ethereum/gateway/L1WethGateway.sol
@@ -43,6 +43,10 @@ contract L1WethGateway is L1ArbitrumExtendedGateway {
         require(_l2Weth != address(0), "INVALID_L2WETH");
         l1Weth = _l1Weth;
         l2Weth = _l2Weth;
+        // we skip the first 2 exit numbers becuase a previous version of this contract had exitNum
+        // stuck at 1 which we have to prevent those exit being traded by reverting with INVALID_EXIT_NUM
+        // starting exitNum at 2 will prevent any new deployment triggering that revert
+        exitNum = 2;
     }
 
     function createOutboundTxCustomRefund(
@@ -110,7 +114,7 @@ contract L1WethGateway is L1ArbitrumExtendedGateway {
     }
 
     /**
-     * @notice  this will revert with exitNum <= 1 to mitigate a known issue
+     * @notice  this will revert with exitNum <= 1 to mitigate a known issue casuing multiple exits with exitNum == 1
      */
     function setRedirectedExit(
         uint256 _exitNum,

--- a/contracts/tokenbridge/ethereum/gateway/L1WethGateway.sol
+++ b/contracts/tokenbridge/ethereum/gateway/L1WethGateway.sol
@@ -110,7 +110,7 @@ contract L1WethGateway is L1ArbitrumExtendedGateway {
     }
 
     /**
-     * @notice  this will revert with exitNum <= 1 to mitigate a known issue casuing multiple exits with exitNum 0 and 1
+     * @notice  this will revert with exitNum <= 1 to mitigate a known issue causing multiple exits with exitNum 0 and 1
      */
     function setRedirectedExit(
         uint256 _exitNum,

--- a/contracts/tokenbridge/ethereum/gateway/L1WethGateway.sol
+++ b/contracts/tokenbridge/ethereum/gateway/L1WethGateway.sol
@@ -110,7 +110,7 @@ contract L1WethGateway is L1ArbitrumExtendedGateway {
     }
 
     /**
-     * @notice  this will revert with exitNum <= 1 to mitigate a known issue casuing multiple exits with exitNum == 1
+     * @notice  this will revert with exitNum <= 1 to mitigate a known issue casuing multiple exits with exitNum 0 and 1
      */
     function setRedirectedExit(
         uint256 _exitNum,

--- a/test/canonicalBridge.l1.ts
+++ b/test/canonicalBridge.l1.ts
@@ -133,7 +133,7 @@ describe('Bridge peripherals layer 1', () => {
     await token.mint()
     await token.transfer(testBridge.address, tokenAmount)
 
-    const exitNum = 0
+    const exitNum = 1
     const withdrawData = ethers.utils.defaultAbiCoder.encode(
       ['uint256', 'bytes'],
       [exitNum, '0x11']
@@ -189,7 +189,7 @@ describe('Bridge peripherals layer 1', () => {
 
     const prevUserBalance = await token.balanceOf(accounts[0].address)
 
-    const exitNum = 0
+    const exitNum = 1
     const withdrawData = ethers.utils.defaultAbiCoder.encode(
       ['uint256', 'bytes'],
       [exitNum, '0x']
@@ -327,7 +327,7 @@ describe('Bridge peripherals layer 1', () => {
 
     const prevUserBalance = await token.balanceOf(accounts[1].address)
 
-    const exitNum = 0
+    const exitNum = 1
     const withdrawData = ethers.utils.defaultAbiCoder.encode(
       ['uint256', 'bytes'],
       [exitNum, '0x']

--- a/test/canonicalBridge.l1.ts
+++ b/test/canonicalBridge.l1.ts
@@ -295,4 +295,77 @@ describe('Bridge peripherals layer 1', () => {
     // 4fb1a07b  =>  outboundTransferCustomRefund(address,address,address,uint256,uint256,uint256,bytes)
     expect(await testBridge.supportsInterface('0x4fb1a07b')).is.true
   })
+
+  // same as "should withdraw erc20 tokens from L2" but trading exit to account[1]
+  it('should be able to trade exit', async function () {
+    const Token = await ethers.getContractFactory('TestERC20')
+    const token = await Token.deploy()
+    // send escrowed tokens to bridge
+    const tokenAmount = 100
+
+    await token.mint()
+    await token.approve(testBridge.address, tokenAmount)
+
+    let data = ethers.utils.defaultAbiCoder.encode(
+      ['uint256', 'bytes'],
+      [maxSubmissionCost, '0x']
+    )
+
+    // router usually does this encoding part
+    data = ethers.utils.defaultAbiCoder.encode(
+      ['address', 'bytes'],
+      [accounts[0].address, data]
+    )
+
+    await testBridge.outboundTransfer(
+      token.address,
+      accounts[0].address,
+      tokenAmount,
+      maxGas,
+      gasPrice,
+      data,
+      {
+        value: maxSubmissionCost + maxGas * gasPrice,
+      }
+    )
+
+    await inbox.setL2ToL1Sender(l2Address)
+
+    const prevUserBalance = await token.balanceOf(accounts[1].address)
+
+    const exitNum = 0
+    const withdrawData = ethers.utils.defaultAbiCoder.encode(
+      ['uint256', 'bytes'],
+      [exitNum, '0x']
+    )
+
+    // trade exit
+    await expect(
+      testBridge.transferExitAndCall(
+        exitNum,
+        accounts[0].address,
+        accounts[1].address,
+        '0x',
+        '0x'
+      )
+    ).to.emit(testBridge, 'WithdrawRedirected')
+
+    await testBridge
+      .connect(await impersonateAccount(inbox.address))
+      .finalizeInboundTransfer(
+        token.address,
+        accounts[0].address,
+        accounts[0].address,
+        tokenAmount,
+        withdrawData
+      )
+
+    const postUserBalance = await token.balanceOf(accounts[1].address)
+
+    assert.equal(
+      prevUserBalance.toNumber() + tokenAmount,
+      postUserBalance.toNumber(),
+      'Tokens not escrowed'
+    )
+  })
 })

--- a/test/canonicalBridge.l1.ts
+++ b/test/canonicalBridge.l1.ts
@@ -123,8 +123,8 @@ describe('Bridge peripherals layer 1', () => {
     ).to.be.revertedWith('EXTRA_DATA_DISABLED')
   })
 
-  // TODO: this does not revert, extra data is not checked on inbound
-  it('should revert on inbound if there is data for post mint call', async function () {
+  // this does not revert, extra data is not checked on inbound but is checked on outbound
+  it.skip('should revert on inbound if there is data for post mint call', async function () {
     const Token = await ethers.getContractFactory('TestERC20')
     const token = await Token.deploy()
     // send escrowed tokens to bridge

--- a/test/canonicalBridge.l1.ts
+++ b/test/canonicalBridge.l1.ts
@@ -123,6 +123,7 @@ describe('Bridge peripherals layer 1', () => {
     ).to.be.revertedWith('EXTRA_DATA_DISABLED')
   })
 
+  // TODO: this does not revert, extra data is not checked on inbound
   it('should revert on inbound if there is data for post mint call', async function () {
     const Token = await ethers.getContractFactory('TestERC20')
     const token = await Token.deploy()
@@ -130,18 +131,7 @@ describe('Bridge peripherals layer 1', () => {
     const tokenAmount = 100
 
     await token.mint()
-    await token.approve(testBridge.address, tokenAmount)
-
-    let data = ethers.utils.defaultAbiCoder.encode(
-      ['uint256', 'bytes'],
-      [maxSubmissionCost, '0x12']
-    )
-
-    // router usually does this encoding part
-    data = ethers.utils.defaultAbiCoder.encode(
-      ['address', 'bytes'],
-      [accounts[0].address, data]
-    )
+    await token.transfer(testBridge.address, tokenAmount)
 
     const exitNum = 0
     const withdrawData = ethers.utils.defaultAbiCoder.encode(
@@ -149,16 +139,20 @@ describe('Bridge peripherals layer 1', () => {
       [exitNum, '0x11']
     )
 
+    await inbox.setL2ToL1Sender(l2Address)
     await expect(
-      testBridge.finalizeInboundTransfer(
-        token.address,
-        accounts[0].address,
-        accounts[0].address,
-        tokenAmount,
-        withdrawData
-      )
-    ).to.be.revertedWith('')
+      testBridge
+        .connect(await impersonateAccount(inbox.address))
+        .finalizeInboundTransfer(
+          token.address,
+          accounts[0].address,
+          accounts[0].address,
+          tokenAmount,
+          withdrawData
+        )
+    ).to.be.revertedWith('EXTRA_DATA_DISABLED')
   })
+
   it('should withdraw erc20 tokens from L2', async function () {
     const Token = await ethers.getContractFactory('TestERC20')
     const token = await Token.deploy()

--- a/test/canonicalBridge.l2.ts
+++ b/test/canonicalBridge.l2.ts
@@ -364,9 +364,14 @@ describe('Bridge peripherals layer 2', () => {
     const balance = await erc20.balanceOf(dest)
     assert.equal(balance.toString(), amount, 'Tokens not minted correctly')
 
+    const prevExitNum = await testBridge.exitNum()
+
     await testBridge.functions[
       'outboundTransfer(address,address,uint256,bytes)'
     ](l1ERC20, accounts[1].address, balance, '0x')
+
+    const newExitNum = await testBridge.exitNum()
+    expect(newExitNum).to.be.gt(prevExitNum)
 
     const newBalance = await erc20.balanceOf(dest)
     assert.equal(newBalance.toString(), '0', 'Tokens not minted correctly')

--- a/test/wethBridge.l1.ts
+++ b/test/wethBridge.l1.ts
@@ -39,6 +39,7 @@ describe('Bridge peripherals layer 1', () => {
     l2Address = accounts[1].address
 
     TestBridge = await ethers.getContractFactory('L1WethGateway')
+    testBridge = await TestBridge.deploy()
 
     const Inbox = await ethers.getContractFactory('InboxMock')
     inbox = await Inbox.deploy()
@@ -361,5 +362,29 @@ describe('Bridge peripherals layer 1', () => {
   it('should support outboundTransferCustomRefund interface', async function () {
     // 4fb1a07b  =>  outboundTransferCustomRefund(address,address,address,uint256,uint256,uint256,bytes)
     expect(await testBridge.supportsInterface('0x4fb1a07b')).is.true
+  })
+
+  it('should be able to transferExitAndCall', async function () {
+    await expect(
+      testBridge.transferExitAndCall(
+        2,
+        accounts[0].address,
+        accounts[1].address,
+        '0x',
+        '0x'
+      )
+    ).to.emit(testBridge, 'WithdrawRedirected')
+  })
+
+  it('should fail to transferExitAndCall exitNum == 1', async function () {
+    await expect(
+      testBridge.transferExitAndCall(
+        1,
+        accounts[0].address,
+        accounts[1].address,
+        '0x',
+        '0x'
+      )
+    ).to.be.revertedWith('INVALID_EXIT_NUM')
   })
 })

--- a/test/wethBridge.l1.ts
+++ b/test/wethBridge.l1.ts
@@ -185,8 +185,8 @@ describe('Bridge peripherals layer 1', () => {
     ).to.be.revertedWith('EXTRA_DATA_DISABLED')
   })
 
-  // TODO: this does not revert, extra data is not checked on inbound
-  it('should revert on inbound if there is data for post mint call', async function () {
+  // this does not revert, extra data is not checked on inbound but is checked on outbound
+  it.skip('should revert on inbound if there is data for post mint call', async function () {
     const Weth = await ethers.getContractFactory('TestWETH9')
     const weth = await Weth.deploy('weth', 'weth')
 

--- a/test/wethBridge.l1.ts
+++ b/test/wethBridge.l1.ts
@@ -346,8 +346,9 @@ describe('Bridge peripherals layer 1', () => {
     expect(await testBridge.supportsInterface('0x4fb1a07b')).is.true
   })
 
+  // TEMPORARILY DISABLING TRADABLE EXIT
   // same as "should withdraw weth from L2" but trading exit to account[1]
-  it('should be able to trade exit', async function () {
+  it.skip('should be able to trade exit', async function () {
     const Weth = await ethers.getContractFactory('TestWETH9')
     const weth = await Weth.deploy('weth', 'weth')
 
@@ -398,17 +399,5 @@ describe('Bridge peripherals layer 1', () => {
       postUserBalance.toNumber(),
       'Weth not escrowed'
     )
-  })
-
-  it('should fail to transferExitAndCall exitNum == 1', async function () {
-    await expect(
-      testBridge.transferExitAndCall(
-        1,
-        accounts[0].address,
-        accounts[1].address,
-        '0x',
-        '0x'
-      )
-    ).to.be.revertedWith('INVALID_EXIT_NUM')
   })
 })

--- a/test/wethBridge.l2.ts
+++ b/test/wethBridge.l2.ts
@@ -126,9 +126,14 @@ describe('Bridge peripherals weth layer 2', () => {
     const balance = await l2Weth.balanceOf(dest)
     assert.equal(balance.toString(), amount, 'Tokens not minted correctly')
 
+    const prevExitNum = await testBridge.exitNum()
+
     await testBridge.functions[
       'outboundTransfer(address,address,uint256,bytes)'
     ](l1WethAddr, accounts[1].address, balance, '0x')
+
+    const newExitNum = await testBridge.exitNum()
+    expect(newExitNum).to.be.gt(prevExitNum)
 
     const newBalance = await l2Weth.balanceOf(dest)
     assert.equal(newBalance.toString(), '0', 'Tokens not burnt correctly')


### PR DESCRIPTION
This PR fix a issue that WETH gateway exitNum is not incrementing correctly
- [x] Increment exitNum in L2WethGateway
- [x] Add tradable exit test cases
- [x] Fix broken tests 
- [x] Disable tradable exit in L1WethGateway

After all withdrawal with duplicated exitNum is executed, we should re-enable tradable exit in L1WethGateway