### PR TITLE
Add UpgradeExecutor to token bridge creation flow

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -1,4 +1,11 @@
-## Goerli - Deploy L1TokenBridgeCreator
-ARB_GOERLI_RPC=""
-ARB_GOERLI_DEPLOYER_KEY=""
+.env-sample
+## RPC endpoints
+BASECHAIN_RPC=""
 ORBIT_RPC=""
+
+## Deployer key used for deploying creator and creating token bridge
+BASECHAIN_DEPLOYER_KEY=""
+
+## Optional args, used for verification script. If not provided info is read from network.json
+ROLLUP_ADDRESS=""
+L1_TOKEN_BRIDGE_CREATOR=""

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
+.gitignore
 .env
 node_modules
+.vscode/
 
 #Hardhat files
 cache

--- a/contracts/tokenbridge/ethereum/L1AtomicTokenBridgeCreator.sol
+++ b/contracts/tokenbridge/ethereum/L1AtomicTokenBridgeCreator.sol
@@ -48,6 +48,7 @@ contract L1AtomicTokenBridgeCreator is Initializable, OwnableUpgradeable {
     error L1AtomicTokenBridgeCreator_OnlyRollupOwner();
     error L1AtomicTokenBridgeCreator_InvalidRouterAddr();
     error L1AtomicTokenBridgeCreator_TemplatesNotSet();
+    error L1AtomicTokenBridgeCreator_ProxyAdminNotFound();
 
     event OrbitTokenBridgeCreated(
         address indexed inbox,
@@ -242,8 +243,11 @@ contract L1AtomicTokenBridgeCreator is Initializable, OwnableUpgradeable {
             address wethGateway
         )
     {
-        address proxyAdmin =
-            address(new ProxyAdmin{ salt: _getL1Salt(OrbitSalts.L1_PROXY_ADMIN, inbox) }());
+        // fetch existing proxy admin from inbox
+        address proxyAdmin = IInbox_ProxyAdmin(inbox).getProxyAdmin();
+        if (proxyAdmin == address(0)) {
+            revert L1AtomicTokenBridgeCreator_ProxyAdminNotFound();
+        }
 
         // deploy router
         address routerTemplate = isUsingFeeToken
@@ -644,4 +648,8 @@ contract L1AtomicTokenBridgeCreator is Initializable, OwnableUpgradeable {
 
 interface IERC20Bridge {
     function nativeToken() external view returns (address);
+}
+
+interface IInbox_ProxyAdmin {
+    function getProxyAdmin() external view returns (address);
 }

--- a/contracts/tokenbridge/ethereum/L1TokenBridgeRetryableSender.sol
+++ b/contracts/tokenbridge/ethereum/L1TokenBridgeRetryableSender.sol
@@ -45,7 +45,8 @@ contract L1TokenBridgeRetryableSender is Initializable, OwnableUpgradeable {
         L1Addresses calldata l1,
         address l2StandardGatewayAddress,
         address rollupOwner,
-        address deployer
+        address deployer,
+        address aliasedL1UpgradeExecutor
     ) external payable onlyOwner {
         bytes memory data = abi.encodeCall(
             L2AtomicTokenBridgeFactory.deployL2Contracts,
@@ -55,7 +56,8 @@ contract L1TokenBridgeRetryableSender is Initializable, OwnableUpgradeable {
                     l2.standardGatewayTemplate.code,
                     l2.customGatewayTemplate.code,
                     l2.wethGatewayTemplate.code,
-                    l2.wethTemplate.code
+                    l2.wethTemplate.code,
+                    l2.upgradeExecutorTemplate.code
                     ),
                 l1.router,
                 l1.standardGateway,
@@ -63,7 +65,8 @@ contract L1TokenBridgeRetryableSender is Initializable, OwnableUpgradeable {
                 l1.wethGateway,
                 l1.weth,
                 l2StandardGatewayAddress,
-                rollupOwner
+                rollupOwner,
+                aliasedL1UpgradeExecutor
             )
         );
 
@@ -89,7 +92,8 @@ contract L1TokenBridgeRetryableSender is Initializable, OwnableUpgradeable {
         L2TemplateAddresses calldata l2,
         L1Addresses calldata l1,
         address l2StandardGatewayAddress,
-        address rollupOwner
+        address rollupOwner,
+        address aliasedL1UpgradeExecutor
     ) external payable onlyOwner {
         bytes memory data = abi.encodeCall(
             L2AtomicTokenBridgeFactory.deployL2Contracts,
@@ -99,7 +103,8 @@ contract L1TokenBridgeRetryableSender is Initializable, OwnableUpgradeable {
                     l2.standardGatewayTemplate.code,
                     l2.customGatewayTemplate.code,
                     "",
-                    ""
+                    "",
+                    l2.upgradeExecutorTemplate.code
                     ),
                 l1.router,
                 l1.standardGateway,
@@ -107,7 +112,8 @@ contract L1TokenBridgeRetryableSender is Initializable, OwnableUpgradeable {
                 address(0),
                 address(0),
                 l2StandardGatewayAddress,
-                rollupOwner
+                rollupOwner,
+                aliasedL1UpgradeExecutor
             )
         );
 
@@ -174,6 +180,7 @@ struct L2TemplateAddresses {
     address customGatewayTemplate;
     address wethGatewayTemplate;
     address wethTemplate;
+    address upgradeExecutorTemplate;
 }
 
 /**

--- a/contracts/tokenbridge/libraries/UpgradeExecutor.sol
+++ b/contracts/tokenbridge/libraries/UpgradeExecutor.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.4;
+
+import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
+
+/// @title  A root contract from which it execute upgrades
+/// @notice Does not contain upgrade logic itself, only the means to call upgrade contracts and execute them
+/// @dev    We use these upgrade contracts as they allow multiple actions to take place in an upgrade
+///         and for these actions to interact. However because we are delegatecalling into these upgrade
+///         contracts, it's important that these upgrade contract do not touch or modify contract state.
+contract UpgradeExecutor is Initializable, AccessControlUpgradeable, ReentrancyGuard {
+    using Address for address;
+
+    bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
+    bytes32 public constant EXECUTOR_ROLE = keccak256("EXECUTOR_ROLE");
+
+    /// @notice Emitted when an upgrade execution occurs
+    event UpgradeExecuted(address indexed upgrade, uint256 value, bytes data);
+
+    /// @notice Initialise the upgrade executor
+    /// @param admin The admin who can update other roles, and itself - ADMIN_ROLE
+    /// @param executors Can call the execute function - EXECUTOR_ROLE
+    function initialize(address admin, address[] memory executors) public initializer {
+        require(admin != address(0), "UpgradeExecutor: zero admin");
+
+        __AccessControl_init();
+
+        _setRoleAdmin(ADMIN_ROLE, ADMIN_ROLE);
+        _setRoleAdmin(EXECUTOR_ROLE, ADMIN_ROLE);
+
+        _setupRole(ADMIN_ROLE, admin);
+        for (uint256 i = 0; i < executors.length; ++i) {
+            _setupRole(EXECUTOR_ROLE, executors[i]);
+        }
+    }
+
+    /// @notice Execute an upgrade by delegate calling an upgrade contract
+    /// @dev    Only executor can call this. Since we're using a delegatecall here the Upgrade contract
+    ///         will have access to the state of this contract - including the roles. Only upgrade contracts
+    ///         that do not touch local state should be used.
+    function execute(address upgrade, bytes memory upgradeCallData)
+        public
+        payable
+        onlyRole(EXECUTOR_ROLE)
+        nonReentrant
+    {
+        // OZ Address library check if the address is a contract and bubble up inner revert reason
+        address(upgrade).functionDelegateCall(
+            upgradeCallData,
+            "UpgradeExecutor: inner delegate call failed without reason"
+        );
+
+        emit UpgradeExecuted(upgrade, msg.value, upgradeCallData);
+    }
+}

--- a/scripts/atomicTokenBridgeDeployer.ts
+++ b/scripts/atomicTokenBridgeDeployer.ts
@@ -21,6 +21,7 @@ import {
   IInbox__factory,
   IERC20Bridge__factory,
   IERC20__factory,
+  UpgradeExecutor__factory,
 } from '../build/types'
 import { JsonRpcProvider } from '@ethersproject/providers'
 import {
@@ -301,6 +302,11 @@ export const deployL1TokenBridgeCreator = async (
     await new L1OrbitCustomGateway__factory(l1Deployer).deploy()
   await feeTokenBasedCustomGatewayTemplate.deployed()
 
+  const upgradeExecutor = await new UpgradeExecutor__factory(
+    l1Deployer
+  ).deploy()
+  await upgradeExecutor.deployed()
+
   const l1Templates = {
     routerTemplate: routerTemplate.address,
     standardGatewayTemplate: standardGatewayTemplate.address,
@@ -311,6 +317,7 @@ export const deployL1TokenBridgeCreator = async (
       feeTokenBasedStandardGatewayTemplate.address,
     feeTokenBasedCustomGatewayTemplate:
       feeTokenBasedCustomGatewayTemplate.address,
+    upgradeExecutor: upgradeExecutor,
   }
 
   /// deploy L2 contracts as placeholders on L1

--- a/scripts/atomicTokenBridgeDeployer.ts
+++ b/scripts/atomicTokenBridgeDeployer.ts
@@ -75,10 +75,12 @@ export const createTokenBridge = async (
     customGateway: L2CustomGateway__factory.bytecode,
     wethGateway: L2WethGateway__factory.bytecode,
     aeWeth: AeWETH__factory.bytecode,
+    upgradeExecutor: UpgradeExecutor__factory.bytecode,
   }
   const gasEstimateToDeployContracts =
     await l2FactoryTemplate.estimateGas.deployL2Contracts(
       l2Code,
+      ethers.Wallet.createRandom().address,
       ethers.Wallet.createRandom().address,
       ethers.Wallet.createRandom().address,
       ethers.Wallet.createRandom().address,
@@ -317,7 +319,7 @@ export const deployL1TokenBridgeCreator = async (
       feeTokenBasedStandardGatewayTemplate.address,
     feeTokenBasedCustomGatewayTemplate:
       feeTokenBasedCustomGatewayTemplate.address,
-    upgradeExecutor: upgradeExecutor,
+    upgradeExecutor: upgradeExecutor.address,
   }
 
   /// deploy L2 contracts as placeholders on L1

--- a/scripts/goerli-deployment/createTokenBridge.ts
+++ b/scripts/goerli-deployment/createTokenBridge.ts
@@ -9,8 +9,8 @@ import * as fs from 'fs'
 dotenv.config()
 
 export const envVars = {
-  baseChainRpc: process.env['ARB_GOERLI_RPC'] as string,
-  baseChainDeployerKey: process.env['ARB_GOERLI_DEPLOYER_KEY'] as string,
+  baseChainRpc: process.env['BASECHAIN_RPC'] as string,
+  baseChainDeployerKey: process.env['BASECHAIN_DEPLOYER_KEY'] as string,
   childChainRpc: process.env['ORBIT_RPC'] as string,
 }
 
@@ -31,9 +31,9 @@ const L1_TOKEN_BRIDGE_CREATOR = '0x4Ba3aC2a2fEf26eAA6d05D71B79fde08Cb3078a9'
  */
 export const createTokenBridgeOnGoerli = async (rollupAddress: string) => {
   if (envVars.baseChainRpc == undefined)
-    throw new Error('Missing ARB_GOERLI_RPC in env vars')
+    throw new Error('Missing BASECHAIN_RPC in env vars')
   if (envVars.baseChainDeployerKey == undefined)
-    throw new Error('Missing ARB_GOERLI_DEPLOYER_KEY in env vars')
+    throw new Error('Missing BASECHAIN_DEPLOYER_KEY in env vars')
   if (envVars.childChainRpc == undefined)
     throw new Error('Missing ORBIT_RPC in env vars')
 

--- a/scripts/goerli-deployment/createTokenBridge.ts
+++ b/scripts/goerli-deployment/createTokenBridge.ts
@@ -14,7 +14,7 @@ export const envVars = {
   childChainRpc: process.env['ORBIT_RPC'] as string,
 }
 
-const L1_TOKEN_BRIDGE_CREATOR = '0x4Ba3aC2a2fEf26eAA6d05D71B79fde08Cb3078a9'
+const L1_TOKEN_BRIDGE_CREATOR = '0x24c77cb51F7a51fB8B69a83a8e36a2fd01B81D82'
 
 /**
  * Steps:

--- a/scripts/goerli-deployment/deployTokenBridgeCreator.ts
+++ b/scripts/goerli-deployment/deployTokenBridgeCreator.ts
@@ -10,8 +10,8 @@ import dotenv from 'dotenv'
 dotenv.config()
 
 export const envVars = {
-  baseChainRpc: process.env['ARB_GOERLI_RPC'] as string,
-  baseChainDeployerKey: process.env['ARB_GOERLI_DEPLOYER_KEY'] as string,
+  baseChainRpc: process.env['BASECHAIN_RPC'] as string,
+  baseChainDeployerKey: process.env['BASECHAIN_DEPLOYER_KEY'] as string,
   childChainRpc: process.env['ORBIT_RPC'] as string,
 }
 
@@ -32,9 +32,9 @@ const ARB_GOERLI_WETH = '0xEe01c0CD76354C383B8c7B4e65EA88D00B06f36f'
  */
 export const deployTokenBridgeCreator = async (rollupAddress: string) => {
   if (envVars.baseChainRpc == undefined)
-    throw new Error('Missing ARB_GOERLI_RPC in env vars')
+    throw new Error('Missing BASECHAIN_RPC in env vars')
   if (envVars.baseChainDeployerKey == undefined)
-    throw new Error('Missing ARB_GOERLI_DEPLOYER_KEY in env vars')
+    throw new Error('Missing BASECHAIN_DEPLOYER_KEY in env vars')
   if (envVars.childChainRpc == undefined)
     throw new Error('Missing ORBIT_RPC in env vars')
 

--- a/scripts/local-deployment/deployCreatorAndCreateTokenBridge.ts
+++ b/scripts/local-deployment/deployCreatorAndCreateTokenBridge.ts
@@ -109,6 +109,7 @@ export const setupTokenBridgeInLocalEnv = async () => {
   return {
     l1Network,
     l2Network,
+    l1TokenBridgeCreator,
   }
 }
 
@@ -192,12 +193,13 @@ export const getLocalNetworks = async (
 }
 
 async function main() {
-  const { l1Network, l2Network } = await setupTokenBridgeInLocalEnv()
+  const { l1Network, l2Network, l1TokenBridgeCreator } =
+    await setupTokenBridgeInLocalEnv()
 
   const NETWORK_FILE = 'network.json'
   fs.writeFileSync(
     NETWORK_FILE,
-    JSON.stringify({ l1Network, l2Network }, null, 2)
+    JSON.stringify({ l1Network, l2Network, l1TokenBridgeCreator }, null, 2)
   )
   console.log(NETWORK_FILE + ' updated')
 }

--- a/test-e2e/tokenBridgeDeploymentTest.ts
+++ b/test-e2e/tokenBridgeDeploymentTest.ts
@@ -125,8 +125,8 @@ describe('tokenBridge', () => {
       )
     }
 
-    await checkL2UpgadeExecutorInitialization(
-      UpgradeExecutor__factory.connect(l1.upgradeExecutor, l1Provider),
+    await checkL2UpgradeExecutorInitialization(
+      UpgradeExecutor__factory.connect(l2.upgradeExecutor, l2Provider),
       l1
     )
 
@@ -247,11 +247,11 @@ async function checkL1WethGatewayInitialization(
   )
 }
 
-async function checkL2UpgadeExecutorInitialization(
+async function checkL2UpgradeExecutorInitialization(
   l2Executor: UpgradeExecutor,
   l1: L1
 ) {
-  console.log('checkL2UpgadeExecutorInitialization')
+  console.log('checkL2UpgradeExecutorInitialization')
 
   //// check assigned/revoked roles are correctly set
   const adminRole = await l2Executor.ADMIN_ROLE()
@@ -259,8 +259,8 @@ async function checkL2UpgadeExecutorInitialization(
 
   expect(await l2Executor.hasRole(adminRole, l2Executor.address)).to.be.true
   expect(await l2Executor.hasRole(executorRole, l1.rollupOwner)).to.be.true
-  expect(await l2Executor.hasRole(executorRole, applyAlias(l1.upgradeExecutor)))
-    .to.be.true
+  const aliasedL1Executor = applyAlias(l1.upgradeExecutor)
+  expect(await l2Executor.hasRole(executorRole, aliasedL1Executor)).to.be.true
 }
 
 //// L2 contracts
@@ -387,9 +387,6 @@ async function checkL1Ownership(l1: L1) {
   expect(await _getOwner(l1.customGateway, l1Provider)).to.be.eq(
     l1.upgradeExecutor
   )
-  expect(await _getOwner(l1.upgradeExecutor, l1Provider)).to.be.eq(
-    l1.upgradeExecutor
-  )
 }
 
 async function checkL2Ownership(l2: L2) {
@@ -486,27 +483,36 @@ async function _getTokenBridgeAddresses(
     upgradeExecutor,
   } = logData.args
   const l1 = {
-    inbox,
-    rollupOwner: owner,
-    router,
-    standardGateway,
-    customGateway,
-    wethGateway,
-    proxyAdmin,
-    upgradeExecutor,
+    inbox: inbox.toLowerCase(),
+    rollupOwner: owner.toLowerCase(),
+    router: router.toLowerCase(),
+    standardGateway: standardGateway.toLowerCase(),
+    customGateway: customGateway.toLowerCase(),
+    wethGateway: wethGateway.toLowerCase(),
+    proxyAdmin: proxyAdmin.toLowerCase(),
+    upgradeExecutor: upgradeExecutor.toLowerCase(),
   }
 
   //// L2
   const l2 = {
-    router: await l1TokenBridgeCreator.getCanonicalL2RouterAddress(),
-    standardGateway:
-      await l1TokenBridgeCreator.getCanonicalL2StandardGatewayAddress(),
-    customGateway:
-      await l1TokenBridgeCreator.getCanonicalL2CustomGatewayAddress(),
-    wethGateway: await l1TokenBridgeCreator.getCanonicalL2WethGatewayAddress(),
-    weth: await l1TokenBridgeCreator.getCanonicalL2WethAddress(),
-    upgradeExecutor:
-      await l1TokenBridgeCreator.getCanonicalL2UpgradeExecutorAddress(),
+    router: (
+      await l1TokenBridgeCreator.getCanonicalL2RouterAddress()
+    ).toLowerCase(),
+    standardGateway: (
+      await l1TokenBridgeCreator.getCanonicalL2StandardGatewayAddress()
+    ).toLowerCase(),
+    customGateway: (
+      await l1TokenBridgeCreator.getCanonicalL2CustomGatewayAddress()
+    ).toLowerCase(),
+    wethGateway: (
+      await l1TokenBridgeCreator.getCanonicalL2WethGatewayAddress()
+    ).toLowerCase(),
+    weth: (
+      await l1TokenBridgeCreator.getCanonicalL2WethAddress()
+    ).toLowerCase(),
+    upgradeExecutor: (
+      await l1TokenBridgeCreator.getCanonicalL2UpgradeExecutorAddress()
+    ).toLowerCase(),
   }
 
   return {
@@ -519,11 +525,13 @@ async function _getProxyAdmin(
   contractAddress: string,
   provider: Provider
 ): Promise<string> {
-  return _getAddressAtStorageSlot(
-    contractAddress,
-    provider,
-    '0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103'
-  )
+  return (
+    await _getAddressAtStorageSlot(
+      contractAddress,
+      provider,
+      '0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103'
+    )
+  ).toLowerCase()
 }
 
 async function _getOwner(

--- a/test-e2e/tokenBridgeDeploymentTest.ts
+++ b/test-e2e/tokenBridgeDeploymentTest.ts
@@ -1,11 +1,10 @@
-import { L1Network, L2Network, getL1Network, getL2Network } from '@arbitrum/sdk'
-import { JsonRpcProvider } from '@ethersproject/providers'
+import { JsonRpcProvider, Provider } from '@ethersproject/providers'
 import {
   BeaconProxyFactory__factory,
   IERC20Bridge__factory,
   IInbox__factory,
-  IOwnable,
   IOwnable__factory,
+  L1AtomicTokenBridgeCreator__factory,
   L1CustomGateway,
   L1CustomGateway__factory,
   L1ERC20Gateway,
@@ -22,179 +21,159 @@ import {
   L2GatewayRouter__factory,
   L2WethGateway,
   L2WethGateway__factory,
-  ProxyAdmin,
-  ProxyAdmin__factory,
+  UpgradeExecutor,
+  UpgradeExecutor__factory,
 } from '../build/types'
+import { RollupCore__factory } from '@arbitrum/sdk/dist/lib/abi/factories/RollupCore__factory'
+import { applyAlias } from '../test/testhelper'
 import path from 'path'
 import fs from 'fs'
-import {
-  addCustomNetwork,
-  l1Networks,
-  l2Networks,
-} from '@arbitrum/sdk/dist/lib/dataEntities/networks'
 import { expect } from 'chai'
 import { ethers } from 'hardhat'
 
 const config = {
+  l1Url: process.env.BASECHAIN_RPC || 'http://localhost:8545',
   l2Url: process.env.ORBIT_RPC || 'http://localhost:8547',
-  l1Url: process.env.ARB_GOERLI_RPC || 'http://localhost:8545',
 }
 
-let _l1Network: L1Network
-let _l2Network: L2Network
-
-let _l1Provider: JsonRpcProvider
-let _l2Provider: JsonRpcProvider
+let l1Provider: JsonRpcProvider
+let l2Provider: JsonRpcProvider
 
 describe('tokenBridge', () => {
   it('should have deployed and initialized token bridge contracts', async function () {
-    const { l1Network, l1Provider, l2Network, l2Provider } =
-      await getProvidersAndSetupNetworks({
-        l1Url: config.l1Url,
-        l2Url: config.l2Url,
-        networkFilename: './network.json',
-      })
+    l1Provider = new JsonRpcProvider(config.l1Url)
+    l2Provider = new JsonRpcProvider(config.l2Url)
 
-    _l1Network = l1Network
-    _l2Network = l2Network
+    /// get rollup and L1 creator addresses as entrypoint, either from env vars or from network.json
+    let rollupAddress: string
+    let l1TokenBridgeCreator: string
+    if (process.env.ROLLUP_ADDRESS && process.env.L1_TOKEN_BRIDGE_CREATOR) {
+      rollupAddress = process.env.ROLLUP_ADDRESS as string
+      l1TokenBridgeCreator = process.env.L1_TOKEN_BRIDGE_CREATOR as string
+    } else {
+      const localNetworkFile = path.join(__dirname, '..', 'network.json')
+      if (fs.existsSync(localNetworkFile)) {
+        const data = JSON.parse(fs.readFileSync(localNetworkFile).toString())
+        rollupAddress = data['l2Network']['ethBridge']['rollup']
+        l1TokenBridgeCreator = data['l1TokenBridgeCreator']
+      } else {
+        throw new Error(
+          "Can't find rollup address info. Either set ROLLUP_ADDRESS env var or provide network.json file"
+        )
+      }
+    }
 
-    _l1Provider = l1Provider
-    _l2Provider = l2Provider
+    /// get addresses
+    const { l1, l2 } = await _getTokenBridgeAddresses(
+      rollupAddress,
+      l1TokenBridgeCreator
+    )
+
+    // console.log(l1)
+    // console.log('############')
+    // console.log(l2)
+    // exit()
 
     //// L1 checks
 
     await checkL1RouterInitialization(
-      L1GatewayRouter__factory.connect(
-        _l2Network.tokenBridge.l1GatewayRouter,
-        l1Provider
-      )
+      L1GatewayRouter__factory.connect(l1.router, l1Provider),
+      l1.inbox,
+      l2
     )
 
     await checkL1StandardGatewayInitialization(
-      L1ERC20Gateway__factory.connect(
-        _l2Network.tokenBridge.l1ERC20Gateway,
-        l1Provider
-      )
+      L1ERC20Gateway__factory.connect(l1.standardGateway, l1Provider),
+      l1,
+      l2
     )
 
     await checkL1CustomGatewayInitialization(
-      L1CustomGateway__factory.connect(
-        _l2Network.tokenBridge.l1CustomGateway,
-        l1Provider
-      )
+      L1CustomGateway__factory.connect(l1.customGateway, l1Provider),
+      l1,
+      l2
     )
 
-    const usingFeeToken = await isUsingFeeToken(
-      _l2Network.ethBridge.inbox,
-      l1Provider
-    )
+    const usingFeeToken = await isUsingFeeToken(l1.inbox, l1Provider)
     if (!usingFeeToken)
       await checkL1WethGatewayInitialization(
-        L1WethGateway__factory.connect(
-          _l2Network.tokenBridge.l1WethGateway,
-          l1Provider
-        )
+        L1WethGateway__factory.connect(l1.wethGateway, l1Provider),
+        l1,
+        l2
       )
 
     //// L2 checks
 
     await checkL2RouterInitialization(
-      L2GatewayRouter__factory.connect(
-        _l2Network.tokenBridge.l2GatewayRouter,
-        l2Provider
-      )
+      L2GatewayRouter__factory.connect(l2.router, l2Provider)
     )
 
     await checkL2StandardGatewayInitialization(
-      L2ERC20Gateway__factory.connect(
-        _l2Network.tokenBridge.l2ERC20Gateway,
-        l2Provider
-      )
+      L2ERC20Gateway__factory.connect(l2.standardGateway, l2Provider)
     )
 
     await checkL2CustomGatewayInitialization(
-      L2CustomGateway__factory.connect(
-        _l2Network.tokenBridge.l2CustomGateway,
-        l2Provider
-      )
-    )
-
-    const rollupOwner = await IOwnable__factory.connect(
-      _l2Network.ethBridge.rollup,
-      l1Provider
-    ).owner()
-    await checkOwnership(
-      rollupOwner.toLowerCase(),
-      ProxyAdmin__factory.connect(
-        _l2Network.tokenBridge.l1ProxyAdmin,
-        l1Provider
-      ),
-      ProxyAdmin__factory.connect(
-        _l2Network.tokenBridge.l2ProxyAdmin,
-        l2Provider
-      ),
-      L1GatewayRouter__factory.connect(
-        _l2Network.tokenBridge.l1GatewayRouter,
-        l1Provider
-      ),
-      L1CustomGateway__factory.connect(
-        _l2Network.tokenBridge.l1CustomGateway,
-        l1Provider
-      )
+      L2CustomGateway__factory.connect(l2.customGateway, l2Provider)
     )
 
     if (!usingFeeToken) {
       await checkL2WethGatewayInitialization(
-        L2WethGateway__factory.connect(
-          _l2Network.tokenBridge.l2WethGateway,
-          l2Provider
-        )
+        L2WethGateway__factory.connect(l2.wethGateway, l2Provider)
       )
     }
+
+    await checkL2UpgadeExecutorInitialization(
+      UpgradeExecutor__factory.connect(l1.upgradeExecutor, l1Provider),
+      l1
+    )
+
+    await checkL1Ownership(l1)
+    await checkL2Ownership(l2)
   })
 })
 
 //// L1 contracts
 
-async function checkL1RouterInitialization(l1Router: L1GatewayRouter) {
+async function checkL1RouterInitialization(
+  l1Router: L1GatewayRouter,
+  inbox: string,
+  l2: L2
+) {
   console.log('checkL1RouterInitialization')
 
   expect((await l1Router.defaultGateway()).toLowerCase()).to.be.eq(
-    _l2Network.tokenBridge.l1ERC20Gateway.toLowerCase()
+    l2.standardGateway.toLowerCase()
   )
-
-  expect((await l1Router.inbox()).toLowerCase()).to.be.eq(
-    _l2Network.ethBridge.inbox.toLowerCase()
-  )
-
+  expect((await l1Router.inbox()).toLowerCase()).to.be.eq(inbox.toLowerCase())
   expect((await l1Router.router()).toLowerCase()).to.be.eq(
     ethers.constants.AddressZero
   )
-
   expect((await l1Router.counterpartGateway()).toLowerCase()).to.be.eq(
-    _l2Network.tokenBridge.l2GatewayRouter.toLowerCase()
+    l2.router.toLowerCase()
   )
 }
 
 async function checkL1StandardGatewayInitialization(
-  l1ERC20Gateway: L1ERC20Gateway
+  l1ERC20Gateway: L1ERC20Gateway,
+  l1: L1,
+  l2: L2
 ) {
   console.log('checkL1StandardGatewayInitialization')
 
   expect((await l1ERC20Gateway.counterpartGateway()).toLowerCase()).to.be.eq(
-    _l2Network.tokenBridge.l2ERC20Gateway.toLowerCase()
+    l2.standardGateway.toLowerCase()
   )
   expect((await l1ERC20Gateway.router()).toLowerCase()).to.be.eq(
-    _l2Network.tokenBridge.l1GatewayRouter.toLowerCase()
+    l1.router.toLowerCase()
   )
   expect((await l1ERC20Gateway.inbox()).toLowerCase()).to.be.eq(
-    _l2Network.ethBridge.inbox.toLowerCase()
+    l1.inbox.toLowerCase()
   )
   expect((await l1ERC20Gateway.l2BeaconProxyFactory()).toLowerCase()).to.be.eq(
     (
       await L2ERC20Gateway__factory.connect(
         await l1ERC20Gateway.counterpartGateway(),
-        _l2Provider
+        l2Provider
       ).beaconProxyFactory()
     ).toLowerCase()
   )
@@ -202,7 +181,7 @@ async function checkL1StandardGatewayInitialization(
     (
       await BeaconProxyFactory__factory.connect(
         await l1ERC20Gateway.l2BeaconProxyFactory(),
-        _l2Provider
+        l2Provider
       ).cloneableProxyHash()
     ).toLowerCase()
   )
@@ -212,52 +191,71 @@ async function checkL1StandardGatewayInitialization(
 }
 
 async function checkL1CustomGatewayInitialization(
-  l1CustomGateway: L1CustomGateway
+  l1CustomGateway: L1CustomGateway,
+  l1: L1,
+  l2: L2
 ) {
   console.log('checkL1CustomGatewayInitialization')
 
   expect((await l1CustomGateway.counterpartGateway()).toLowerCase()).to.be.eq(
-    _l2Network.tokenBridge.l2CustomGateway.toLowerCase()
+    l2.customGateway.toLowerCase()
   )
 
   expect((await l1CustomGateway.router()).toLowerCase()).to.be.eq(
-    _l2Network.tokenBridge.l1GatewayRouter.toLowerCase()
+    l1.router.toLowerCase()
   )
 
   expect((await l1CustomGateway.inbox()).toLowerCase()).to.be.eq(
-    _l2Network.ethBridge.inbox.toLowerCase()
+    l1.inbox.toLowerCase()
   )
-
-  // TODO
-  // owner check
 
   expect((await l1CustomGateway.whitelist()).toLowerCase()).to.be.eq(
     ethers.constants.AddressZero
   )
 }
 
-async function checkL1WethGatewayInitialization(l1WethGateway: L1WethGateway) {
+async function checkL1WethGatewayInitialization(
+  l1WethGateway: L1WethGateway,
+  l1: L1,
+  l2: L2
+) {
   console.log('checkL1WethGatewayInitialization')
 
   expect((await l1WethGateway.counterpartGateway()).toLowerCase()).to.be.eq(
-    _l2Network.tokenBridge.l2WethGateway.toLowerCase()
+    l2.wethGateway.toLowerCase()
   )
 
   expect((await l1WethGateway.router()).toLowerCase()).to.be.eq(
-    _l2Network.tokenBridge.l1GatewayRouter.toLowerCase()
+    l1.router.toLowerCase()
   )
 
   expect((await l1WethGateway.inbox()).toLowerCase()).to.be.eq(
-    _l2Network.ethBridge.inbox.toLowerCase()
+    l1.inbox.toLowerCase()
   )
 
-  expect((await l1WethGateway.l1Weth()).toLowerCase()).to.be.eq(
-    _l2Network.tokenBridge.l1Weth.toLowerCase()
+  expect((await l1WethGateway.l1Weth()).toLowerCase()).to.not.be.eq(
+    ethers.constants.AddressZero
   )
 
-  expect((await l1WethGateway.l2Weth()).toLowerCase()).to.be.eq(
-    _l2Network.tokenBridge.l2Weth.toLowerCase()
+  expect((await l1WethGateway.l2Weth()).toLowerCase()).to.not.be.eq(
+    ethers.constants.AddressZero
   )
+}
+
+async function checkL2UpgadeExecutorInitialization(
+  l2Executor: UpgradeExecutor,
+  l1: L1
+) {
+  console.log('checkL2UpgadeExecutorInitialization')
+
+  //// check assigned/revoked roles are correctly set
+  const adminRole = await l2Executor.ADMIN_ROLE()
+  const executorRole = await l2Executor.EXECUTOR_ROLE()
+
+  expect(await l2Executor.hasRole(adminRole, l2Executor.address)).to.be.true
+  expect(await l2Executor.hasRole(executorRole, l1.rollupOwner)).to.be.true
+  expect(await l2Executor.hasRole(executorRole, applyAlias(l1.upgradeExecutor)))
+    .to.be.true
 }
 
 //// L2 contracts
@@ -344,76 +342,66 @@ async function checkL2WethGatewayInitialization(l2WethGateway: L2WethGateway) {
   )
 }
 
-async function checkOwnership(
-  rollupOwner: string,
-  l1ProxyAdmin: ProxyAdmin,
-  l2ProxyAdmin: ProxyAdmin,
-  l1Router: L1GatewayRouter,
-  l1CustomGateway: L1CustomGateway
-) {
-  console.log('checkL2ProxyAdminInitialization')
+async function checkL1Ownership(l1: L1) {
+  console.log('checkL1Ownership')
 
-  expect(rollupOwner).to.be.eq((await l1ProxyAdmin.owner()).toLowerCase())
-  expect(rollupOwner).to.be.eq((await l2ProxyAdmin.owner()).toLowerCase())
-  expect(rollupOwner).to.be.eq((await l1Router.owner()).toLowerCase())
-  expect(rollupOwner).to.be.eq((await l1CustomGateway.owner()).toLowerCase())
-}
-
-export const getProvidersAndSetupNetworks = async (setupConfig: {
-  l1Url: string
-  l2Url: string
-  networkFilename?: string
-}): Promise<{
-  l1Network: L1Network
-  l2Network: L2Network
-  l1Provider: JsonRpcProvider
-  l2Provider: JsonRpcProvider
-}> => {
-  const l1Provider = new JsonRpcProvider(setupConfig.l1Url)
-  const l2Provider = new JsonRpcProvider(setupConfig.l2Url)
-
-  if (setupConfig.networkFilename) {
-    // check if theres an existing network available
-    const localNetworkFile = path.join(
-      __dirname,
-      '..',
-      setupConfig.networkFilename
+  // check proxyAdmins
+  expect(await _getProxyAdmin(l1.router, l1Provider)).to.be.eq(l1.proxyAdmin)
+  expect(await _getProxyAdmin(l1.standardGateway, l1Provider)).to.be.eq(
+    l1.proxyAdmin
+  )
+  expect(await _getProxyAdmin(l1.customGateway, l1Provider)).to.be.eq(
+    l1.proxyAdmin
+  )
+  if (l1.wethGateway !== ethers.constants.AddressZero) {
+    expect(await _getProxyAdmin(l1.wethGateway, l1Provider)).to.be.eq(
+      l1.proxyAdmin
     )
-    if (fs.existsSync(localNetworkFile)) {
-      const { l1Network, l2Network } = JSON.parse(
-        fs.readFileSync(localNetworkFile).toString()
-      ) as {
-        l1Network: L1Network
-        l2Network: L2Network
-      }
-
-      const existingL1Network = l1Networks[l1Network.chainID.toString()]
-      const existingL2Network = l2Networks[l2Network.chainID.toString()]
-      if (!existingL2Network) {
-        addCustomNetwork({
-          // dont add the l1 network if it's already been added
-          customL1Network: existingL1Network ? undefined : l1Network,
-          customL2Network: l2Network,
-        })
-      }
-
-      return {
-        l1Network,
-        l1Provider,
-        l2Network,
-        l2Provider,
-      }
-    } else throw Error(`Missing file ${localNetworkFile}`)
-  } else {
-    return {
-      l1Network: await getL1Network(l1Provider),
-      l1Provider,
-      l2Network: await getL2Network(l2Provider),
-      l2Provider,
-    }
   }
+  expect(await _getProxyAdmin(l1.upgradeExecutor, l1Provider)).to.be.eq(
+    l1.proxyAdmin
+  )
+
+  // check ownables
+  expect(await _getOwner(l1.proxyAdmin, l1Provider)).to.be.eq(
+    l1.upgradeExecutor
+  )
+  expect(await _getOwner(l1.router, l1Provider)).to.be.eq(l1.upgradeExecutor)
+  expect(await _getOwner(l1.customGateway, l1Provider)).to.be.eq(
+    l1.upgradeExecutor
+  )
+  expect(await _getOwner(l1.upgradeExecutor, l1Provider)).to.be.eq(
+    l1.upgradeExecutor
+  )
 }
 
+async function checkL2Ownership(l2: L2) {
+  console.log('checkL2Ownership')
+
+  const l2ProxyAdmin = await _getProxyAdmin(l2.router, l2Provider)
+
+  // check proxyAdmins
+  expect(await _getProxyAdmin(l2.router, l2Provider)).to.be.eq(l2ProxyAdmin)
+  expect(await _getProxyAdmin(l2.standardGateway, l2Provider)).to.be.eq(
+    l2ProxyAdmin
+  )
+  expect(await _getProxyAdmin(l2.customGateway, l2Provider)).to.be.eq(
+    l2ProxyAdmin
+  )
+  if (l2.wethGateway !== ethers.constants.AddressZero) {
+    expect(await _getProxyAdmin(l2.wethGateway, l2Provider)).to.be.eq(
+      l2ProxyAdmin
+    )
+  }
+  expect(await _getProxyAdmin(l2.upgradeExecutor, l2Provider)).to.be.eq(
+    l2ProxyAdmin
+  )
+
+  // check ownables
+  expect(await _getOwner(l2ProxyAdmin, l2Provider)).to.be.eq(l2.upgradeExecutor)
+}
+
+//// utils
 async function isUsingFeeToken(inbox: string, l1Provider: JsonRpcProvider) {
   const bridge = await IInbox__factory.connect(inbox, l1Provider).bridge()
 
@@ -424,4 +412,145 @@ async function isUsingFeeToken(inbox: string, l1Provider: JsonRpcProvider) {
   }
 
   return true
+}
+
+async function _getTokenBridgeAddresses(
+  rollupAddress: string,
+  l1TokenBridgeCreatorAddress: string
+) {
+  const inboxAddress = await RollupCore__factory.connect(
+    rollupAddress,
+    l1Provider
+  ).inbox()
+
+  const l1TokenBridgeCreator = L1AtomicTokenBridgeCreator__factory.connect(
+    l1TokenBridgeCreatorAddress,
+    l1Provider
+  )
+
+  //// L1
+  // find all the events emitted by this address
+  const filter: ethers.providers.Filter = {
+    address: l1TokenBridgeCreatorAddress,
+    topics: [
+      ethers.utils.id('OrbitTokenBridgeCreated'),
+      ethers.utils.hexZeroPad(inboxAddress, 32),
+    ],
+  }
+
+  const currentBlock = await l1Provider.getBlockNumber()
+  const fromBlock = currentBlock - 100000 // ~last 24h on
+  const logs = await l1Provider.getLogs({
+    ...filter,
+    fromBlock: fromBlock,
+    toBlock: 'latest',
+  })
+
+  if (logs.length === 0) {
+    throw new Error("Couldn't find any OrbitTokenBridgeCreated events")
+  }
+
+  const logData = l1TokenBridgeCreator.interface.parseLog(logs[0])
+  console.log(logData)
+
+  const {
+    inbox,
+    owner,
+    router,
+    standardGateway,
+    customGateway,
+    wethGateway,
+    proxyAdmin,
+    upgradeExecutor,
+  } = logData.args
+  const l1 = {
+    inbox,
+    rollupOwner: owner,
+    router,
+    standardGateway,
+    customGateway,
+    wethGateway,
+    proxyAdmin,
+    upgradeExecutor,
+  }
+
+  //// L2
+  const l2 = {
+    router: await l1TokenBridgeCreator.getCanonicalL2RouterAddress(),
+    standardGateway:
+      await l1TokenBridgeCreator.getCanonicalL2StandardGatewayAddress(),
+    customGateway:
+      await l1TokenBridgeCreator.getCanonicalL2CustomGatewayAddress(),
+    wethGateway: await l1TokenBridgeCreator.getCanonicalL2WethGatewayAddress(),
+    weth: await l1TokenBridgeCreator.getCanonicalL2WethAddress(),
+    upgradeExecutor:
+      await l1TokenBridgeCreator.getCanonicalL2UpgradeExecutorAddress(),
+  }
+
+  return {
+    l1,
+    l2,
+  }
+}
+
+async function _getProxyAdmin(
+  contractAddress: string,
+  provider: Provider
+): Promise<string> {
+  return _getAddressAtStorageSlot(
+    contractAddress,
+    provider,
+    '0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103'
+  )
+}
+
+async function _getOwner(
+  contractAddress: string,
+  provider: Provider
+): Promise<string> {
+  return (
+    await IOwnable__factory.connect(contractAddress, provider).owner()
+  ).toLowerCase()
+}
+
+async function _getAddressAtStorageSlot(
+  contractAddress: string,
+  provider: Provider,
+  storageSlotBytes: string
+): Promise<string> {
+  const storageValue = await provider.getStorageAt(
+    contractAddress,
+    storageSlotBytes
+  )
+
+  if (!storageValue) {
+    return ''
+  }
+
+  // remove excess bytes
+  const formatAddress =
+    storageValue.substring(0, 2) + storageValue.substring(26)
+
+  // return address as checksum address
+  return ethers.utils.getAddress(formatAddress)
+}
+
+interface L1 {
+  inbox: string
+  rollupOwner: string
+  router: string
+  standardGateway: string
+  customGateway: string
+  wethGateway: string
+  proxyAdmin: string
+  upgradeExecutor: string
+}
+
+interface L2 {
+  router: string
+  standardGateway: string
+  customGateway: string
+  wethGateway: string
+  weth: string
+  upgradeExecutor: string
 }


### PR DESCRIPTION
On L1 side of token bridge: use existing rollup's proxy admin (fetch it from inbox). 
On L2 side of token bridge: create new proxy admin for L2 contracts. Also create new UpgradeExecutor. Executor is the owner of proxy admin. Rollup owner and aliased L1 executor have EXECUTOR role.