### PR TITLE
Derive token bridge addresses on child chain from chain ID

### DIFF
--- a/contracts/tokenbridge/arbitrum/L2AtomicTokenBridgeFactory.sol
+++ b/contracts/tokenbridge/arbitrum/L2AtomicTokenBridgeFactory.sol
@@ -241,12 +241,12 @@ contract L2AtomicTokenBridgeFactory {
     }
 
     /**
-     * In addition to hard-coded prefix, salt for L2 contracts depends on msg.sender. Deploying L2 token bridge contracts is
-     * permissionless. By making msg.sender part of the salt we know exactly which set of contracts is the "canonical" one,
+     * In addition to hard-coded prefix, salt for L2 contracts depends on msg.sender and the chainId. Deploying L2 token bridge contracts is
+     * permissionless. By making msg.sender part of the salt we know exactly which set of contracts is the "canonical" one for given chain,
      * deployed by L1TokenBridgeRetryableSender via retryable ticket.
      */
     function _getL2Salt(bytes memory prefix) internal view returns (bytes32) {
-        return keccak256(abi.encodePacked(prefix, msg.sender));
+        return keccak256(abi.encodePacked(prefix, block.chainid, msg.sender));
     }
 
     /**

--- a/scripts/goerli-deployment/deployTokenBridgeCreator.ts
+++ b/scripts/goerli-deployment/deployTokenBridgeCreator.ts
@@ -124,7 +124,7 @@ const registerGoerliNetworks = async (
 
 async function main() {
   // this is just random Orbit rollup that will be used to estimate gas needed to deploy L2 token bridge factory via retryable
-  const rollupAddress = '0xe16E44efb06F33ed700618A738E24FeFd7801A84'
+  const rollupAddress = '0x15B318F69107c8122034D07cfcf1787095eF9A89'
   const { l1TokenBridgeCreator, retryableSender } =
     await deployTokenBridgeCreator(rollupAddress)
   console.log('L1TokenBridgeCreator:', l1TokenBridgeCreator.address)

--- a/test-e2e/tokenBridgeDeploymentTest.ts
+++ b/test-e2e/tokenBridgeDeploymentTest.ts
@@ -4,6 +4,7 @@ import {
   IERC20Bridge__factory,
   IInbox__factory,
   IOwnable__factory,
+  IRollupCore__factory,
   L1AtomicTokenBridgeCreator__factory,
   L1CustomGateway,
   L1CustomGateway__factory,
@@ -460,6 +461,7 @@ async function _getTokenBridgeAddresses(
 
   //// L1
   // find all the events emitted by this address
+
   const filter: Filter = {
     address: l1TokenBridgeCreatorAddress,
     topics: [
@@ -511,27 +513,32 @@ async function _getTokenBridgeAddresses(
 
   const usingFeeToken = await isUsingFeeToken(l1.inbox, l1Provider)
 
+  const chainId = await IRollupCore__factory.connect(
+    rollupAddress,
+    l1Provider
+  ).chainId()
+
   //// L2
   const l2 = {
     router: (
-      await l1TokenBridgeCreator.getCanonicalL2RouterAddress()
+      await l1TokenBridgeCreator.getCanonicalL2RouterAddress(chainId)
     ).toLowerCase(),
     standardGateway: (
-      await l1TokenBridgeCreator.getCanonicalL2StandardGatewayAddress()
+      await l1TokenBridgeCreator.getCanonicalL2StandardGatewayAddress(chainId)
     ).toLowerCase(),
     customGateway: (
-      await l1TokenBridgeCreator.getCanonicalL2CustomGatewayAddress()
+      await l1TokenBridgeCreator.getCanonicalL2CustomGatewayAddress(chainId)
     ).toLowerCase(),
     wethGateway: (usingFeeToken
       ? ethers.constants.AddressZero
-      : await l1TokenBridgeCreator.getCanonicalL2WethGatewayAddress()
+      : await l1TokenBridgeCreator.getCanonicalL2WethGatewayAddress(chainId)
     ).toLowerCase(),
     weth: (usingFeeToken
       ? ethers.constants.AddressZero
-      : await l1TokenBridgeCreator.getCanonicalL2WethAddress()
+      : await l1TokenBridgeCreator.getCanonicalL2WethAddress(chainId)
     ).toLowerCase(),
     upgradeExecutor: (
-      await l1TokenBridgeCreator.getCanonicalL2UpgradeExecutorAddress()
+      await l1TokenBridgeCreator.getCanonicalL2UpgradeExecutorAddress(chainId)
     ).toLowerCase(),
   }
 

--- a/test-foundry/util/TestUtil.sol
+++ b/test-foundry/util/TestUtil.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.4;
 
 import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";


### PR DESCRIPTION
Add chainId to the L2 salt which is used to derive L2 addresses. This means L2 addresses won't be same across every Orbit chain. Each Orbit chain will have its own set of canonical addresses. 