### PR TITLE
setGateways() in OrbitGatewayRouter should not be payable

### DIFF
--- a/contracts/tokenbridge/ethereum/gateway/L1OrbitGatewayRouter.sol
+++ b/contracts/tokenbridge/ethereum/gateway/L1OrbitGatewayRouter.sol
@@ -109,7 +109,7 @@ contract L1OrbitGatewayRouter is L1GatewayRouter {
         uint256 _gasPriceBid,
         uint256 _maxSubmissionCost,
         uint256 _feeAmount
-    ) external payable onlyOwner returns (uint256) {
+    ) external onlyOwner returns (uint256) {
         return
             _setGateways(
                 _token,


### PR DESCRIPTION
This function uses the fee paying token instead of ETH for fees.