### PR TITLE
Make sure ether is not sent in ERC20 token bridge

### DIFF
--- a/contracts/tokenbridge/ethereum/gateway/L1OrbitCustomGateway.sol
+++ b/contracts/tokenbridge/ethereum/gateway/L1OrbitCustomGateway.sol
@@ -89,7 +89,7 @@ contract L1OrbitCustomGateway is L1CustomGateway {
         uint256 _gasPriceBid,
         uint256 _maxSubmissionCost,
         uint256 _feeAmount
-    ) external payable onlyOwner returns (uint256) {
+    ) external onlyOwner returns (uint256) {
         return
             _forceRegisterTokenToL2(
                 _l1Addresses,

--- a/contracts/tokenbridge/ethereum/gateway/L1OrbitERC20Gateway.sol
+++ b/contracts/tokenbridge/ethereum/gateway/L1OrbitERC20Gateway.sol
@@ -25,6 +25,9 @@ contract L1OrbitERC20Gateway is L1ERC20Gateway {
         uint256 _gasPriceBid,
         bytes calldata _data
     ) public payable override returns (bytes memory res) {
+        // fees are paid in native token, so there is no use for ether
+        require(msg.value == 0, "NO_VALUE");
+
         // We don't allow bridging of native token to avoid having multiple representations of it 
         // on child chain. Native token can be bridged directly through inbox using depositERC20().
         require(_l1Token != _getNativeFeeToken(), "NOT_ALLOWED_TO_BRIDGE_FEE_TOKEN");

--- a/test-foundry/L1ArbitrumExtendedGateway.t.sol
+++ b/test-foundry/L1ArbitrumExtendedGateway.t.sol
@@ -146,7 +146,7 @@ abstract contract L1ArbitrumExtendedGatewayTest is Test {
 
         vm.prank(router);
         vm.expectRevert("EXTRA_DATA_DISABLED");
-        l1Gateway.outboundTransferCustomRefund{ value: 1 ether }(
+        l1Gateway.outboundTransferCustomRefund(
             address(token),
             user,
             user,
@@ -162,7 +162,7 @@ abstract contract L1ArbitrumExtendedGatewayTest is Test {
 
         vm.prank(router);
         vm.expectRevert("L1_NOT_CONTRACT");
-        l1Gateway.outboundTransferCustomRefund{ value: 1 ether }(
+        l1Gateway.outboundTransferCustomRefund(
             address(invalidTokenAddress),
             user,
             user,
@@ -175,7 +175,7 @@ abstract contract L1ArbitrumExtendedGatewayTest is Test {
 
     function test_outboundTransferCustomRefund_revert_NotFromRouter() public {
         vm.expectRevert("NOT_FROM_ROUTER");
-        l1Gateway.outboundTransferCustomRefund{ value: 1 ether }(
+        l1Gateway.outboundTransferCustomRefund(
             address(token),
             user,
             user,

--- a/test-foundry/L1ERC20Gateway.t.sol
+++ b/test-foundry/L1ERC20Gateway.t.sol
@@ -182,7 +182,7 @@ contract L1ERC20GatewayTest is L1ArbitrumExtendedGatewayTest {
 
         vm.prank(router);
         vm.expectRevert("ERC20: insufficient allowance");
-        l1Gateway.outboundTransferCustomRefund{ value: 1 ether }(
+        l1Gateway.outboundTransferCustomRefund(
             address(token),
             user,
             user,


### PR DESCRIPTION
Make  function non-payable `forceRegisterTokenToL2` in L1OrbitCustomGateway

 In `outboundTransferCustomRefund` of  L1OrbitERC20Gateway require there's no value sent