### PR TITLE
Add multicall getters

### DIFF
--- a/contracts/tokenbridge/ethereum/L1AtomicTokenBridgeCreator.sol
+++ b/contracts/tokenbridge/ethereum/L1AtomicTokenBridgeCreator.sol
@@ -108,6 +108,9 @@ contract L1AtomicTokenBridgeCreator is Initializable, OwnableUpgradeable {
     // WETH address on L1
     address public l1Weth;
 
+    // Multicall address on L1
+    address public l1Multicall;
+
     // immutable canonical address for L2 factory
     // other canonical addresses (dependent on L2 template implementations) can be fetched through `getCanonicalL2***Address` functions
     address public canonicalL2FactoryAddress;
@@ -147,6 +150,7 @@ contract L1AtomicTokenBridgeCreator is Initializable, OwnableUpgradeable {
         address _l2WethTemplate,
         address _l2MulticallTemplate,
         address _l1Weth,
+        address _l1Multicall,
         uint256 _gasLimitForL2FactoryDeployment
     ) external onlyOwner {
         l1Templates = _l1Templates;
@@ -160,6 +164,7 @@ contract L1AtomicTokenBridgeCreator is Initializable, OwnableUpgradeable {
         l2MulticallTemplate = _l2MulticallTemplate;
 
         l1Weth = _l1Weth;
+        l1Multicall = _l1Multicall;
 
         gasLimitForL2FactoryDeployment = _gasLimitForL2FactoryDeployment;
 

--- a/contracts/tokenbridge/ethereum/L1AtomicTokenBridgeCreator.sol
+++ b/contracts/tokenbridge/ethereum/L1AtomicTokenBridgeCreator.sol
@@ -103,24 +103,26 @@ contract L1AtomicTokenBridgeCreator is Initializable, OwnableUpgradeable {
     address public l2CustomGatewayTemplate;
     address public l2WethGatewayTemplate;
     address public l2WethTemplate;
-    address public l2MulticallTemplate;
 
     // WETH address on L1
     address public l1Weth;
 
-    // Multicall address on L1
+    // multicall address on L1
     address public l1Multicall;
 
     // immutable canonical address for L2 factory
     // other canonical addresses (dependent on L2 template implementations) can be fetched through `getCanonicalL2***Address` functions
     address public canonicalL2FactoryAddress;
 
-    // Code hash used for calculation of L2 multicall address.
-    // Note - assumption is that hash of l2MulticallTemplate's bytecode provided in `setTemplate` matches this code hash
+    // immutable ArbMulticall2 template deployed on L1
+    // Note - due to contract size limits, multicall template and its bytecode hash are set in constructor as immutables
+    address public immutable l2MulticallTemplate;
+    // code hash used for calculation of L2 multicall address
     bytes32 public immutable ARB_MULTICALL_CODE_HASH;
 
-    constructor() {
-        ARB_MULTICALL_CODE_HASH = keccak256(_creationCodeFor(type(ArbMulticall2).runtimeCode));
+    constructor(address _l2MulticallTemplate) {
+        l2MulticallTemplate = _l2MulticallTemplate;
+        ARB_MULTICALL_CODE_HASH = keccak256(_creationCodeFor(l2MulticallTemplate.code));
         _disableInitializers();
     }
 
@@ -148,7 +150,6 @@ contract L1AtomicTokenBridgeCreator is Initializable, OwnableUpgradeable {
         address _l2CustomGatewayTemplate,
         address _l2WethGatewayTemplate,
         address _l2WethTemplate,
-        address _l2MulticallTemplate,
         address _l1Weth,
         address _l1Multicall,
         uint256 _gasLimitForL2FactoryDeployment
@@ -161,7 +162,6 @@ contract L1AtomicTokenBridgeCreator is Initializable, OwnableUpgradeable {
         l2CustomGatewayTemplate = _l2CustomGatewayTemplate;
         l2WethGatewayTemplate = _l2WethGatewayTemplate;
         l2WethTemplate = _l2WethTemplate;
-        l2MulticallTemplate = _l2MulticallTemplate;
 
         l1Weth = _l1Weth;
         l1Multicall = _l1Multicall;

--- a/contracts/tokenbridge/ethereum/L1AtomicTokenBridgeCreator.sol
+++ b/contracts/tokenbridge/ethereum/L1AtomicTokenBridgeCreator.sol
@@ -107,7 +107,7 @@ contract L1AtomicTokenBridgeCreator is Initializable, OwnableUpgradeable {
     // WETH address on L1
     address public l1Weth;
 
-    // multicall address on L1
+    // Multicall2 address on L1, this should NOT be ArbMulticall2
     address public l1Multicall;
 
     // immutable canonical address for L2 factory

--- a/contracts/tokenbridge/ethereum/L1AtomicTokenBridgeCreator.sol
+++ b/contracts/tokenbridge/ethereum/L1AtomicTokenBridgeCreator.sol
@@ -112,7 +112,12 @@ contract L1AtomicTokenBridgeCreator is Initializable, OwnableUpgradeable {
     // other canonical addresses (dependent on L2 template implementations) can be fetched through `getCanonicalL2***Address` functions
     address public canonicalL2FactoryAddress;
 
+    // Code hash used for calculation of L2 multicall address.
+    // Note - assumption is that hash of l2MulticallTemplate's bytecode provided in `setTemplate` matches this code hash
+    bytes32 public immutable ARB_MULTICALL_CODE_HASH;
+
     constructor() {
+        ARB_MULTICALL_CODE_HASH = keccak256(_creationCodeFor(type(ArbMulticall2).runtimeCode));
         _disableInitializers();
     }
 
@@ -596,6 +601,14 @@ contract L1AtomicTokenBridgeCreator is Initializable, OwnableUpgradeable {
             _getL2Salt(OrbitSalts.L2_EXECUTOR_LOGIC, chainId),
             _getL2Salt(OrbitSalts.L2_EXECUTOR, chainId),
             chainId
+        );
+    }
+
+    function getCanonicalL2Multicall(uint256 chainId) public view returns (address) {
+        return Create2.computeAddress(
+            _getL2Salt(OrbitSalts.L2_MULTICALL, chainId),
+            ARB_MULTICALL_CODE_HASH,
+            canonicalL2FactoryAddress
         );
     }
 

--- a/scripts/atomicTokenBridgeDeployer.ts
+++ b/scripts/atomicTokenBridgeDeployer.ts
@@ -24,6 +24,7 @@ import {
   ArbMulticall2__factory,
   IRollupCore__factory,
   IBridge__factory,
+  Multicall2__factory,
 } from '../build/types'
 import {
   abi as UpgradeExecutorABI,
@@ -378,6 +379,9 @@ export const deployL1TokenBridgeCreator = async (
   ).deploy()
   await l2MulticallAddressOnL1.deployed()
 
+  const l1Multicall = await new Multicall2__factory(l1Deployer).deploy()
+  await l1Multicall.deployed()
+
   //// run retryable estimate for deploying L2 factory
   const deployFactoryGasParams = await getEstimateForDeployingFactory(
     l1Deployer,
@@ -395,6 +399,7 @@ export const deployL1TokenBridgeCreator = async (
       l2WethAddressOnL1.address,
       l2MulticallAddressOnL1.address,
       l1WethAddress,
+      l1Multicall.address,
       deployFactoryGasParams.gasLimit
     )
   ).wait()
@@ -503,6 +508,12 @@ export const deployL1TokenBridgeCreator = async (
       'l2MulticallAddressOnL1',
       l2MulticallAddressOnL1.address
     )
+
+    await l1Verifier.verifyWithAddress(
+      'l1Multicall',
+      l1Multicall.address
+    )
+
     await new Promise(resolve => setTimeout(resolve, 2000))
     console.log('\n\n Contract verification done \n\n')
   }

--- a/scripts/contractVerifier.ts
+++ b/scripts/contractVerifier.ts
@@ -51,6 +51,7 @@ export class ContractVerifier {
       'contracts/tokenbridge/arbitrum/gateway/L2WethGateway.sol:L2WethGateway',
     l2WethAddressOnL1: 'contracts/tokenbridge/libraries/aeWETH.sol:aeWETH',
     l2MulticallAddressOnL1: 'contracts/rpc-utils/MulticallV2.sol:ArbMulticall2',
+    l1Multicall: 'contracts/rpc-utils/MulticallV2.sol:Multicall2',
   }
 
   constructor(chainId: number, apiKey: string) {


### PR DESCRIPTION
Commit adds:
 - provide l2MulticallTemplate in constructor. It is set as immutable and code hash is stored, so it can be used to calculate address of canonical L2 multicall. We do this in constructor because of contract size limits
 - deploy L1 multicall by script when token bridge is created. Provide the address along with templates. We store L1 multicall address for client convenience  