### PR TITLE
Init logic contracts

### DIFF
--- a/contracts/tokenbridge/arbitrum/L2AtomicTokenBridgeFactory.sol
+++ b/contracts/tokenbridge/arbitrum/L2AtomicTokenBridgeFactory.sol
@@ -119,6 +119,10 @@ contract L2AtomicTokenBridgeFactory {
             Create2.deploy(0, _getL2Salt(OrbitSalts.L2_ROUTER_LOGIC), _creationCodeFor(runtimeCode));
         ProxyAdmin(proxyAdmin).upgrade(ITransparentUpgradeableProxy(canonicalRouter), routerLogic);
 
+        // init logic contract with dummy values
+        address dead = address(0x000000000000000000000000000000000000dEaD);
+        L2GatewayRouter(routerLogic).initialize(dead, dead);
+
         // init
         L2GatewayRouter(canonicalRouter).initialize(l1Router, l2StandardGatewayCanonicalAddress);
 
@@ -146,6 +150,10 @@ contract L2AtomicTokenBridgeFactory {
         ProxyAdmin(proxyAdmin).upgrade(
             ITransparentUpgradeableProxy(canonicalStdGateway), stdGatewayLogic
         );
+
+        // init logic contract with dummy values
+        address dead = address(0x000000000000000000000000000000000000dEaD);
+        L2ERC20Gateway(stdGatewayLogic).initialize(dead, dead, dead);
 
         // create beacon
         StandardArbERC20 standardArbERC20 = new StandardArbERC20{
@@ -189,8 +197,12 @@ contract L2AtomicTokenBridgeFactory {
             ITransparentUpgradeableProxy(canonicalCustomGateway), customGatewayLogicAddress
         );
 
+        // init logic contract with dummy values
+        address dead = address(0x000000000000000000000000000000000000dEaD);
+        L2CustomGateway(customGatewayLogicAddress).initialize(dead, dead);
+
         // init
-        L2GatewayRouter(canonicalCustomGateway).initialize(l1CustomGateway, router);
+        L2CustomGateway(canonicalCustomGateway).initialize(l1CustomGateway, router);
     }
 
     function _deployWethGateway(
@@ -228,6 +240,10 @@ contract L2AtomicTokenBridgeFactory {
         ProxyAdmin(proxyAdmin).upgrade(
             ITransparentUpgradeableProxy(canonicalL2WethGateway), l2WethGatewayLogic
         );
+
+        // init logic contract with dummy values
+        address dead = address(0x000000000000000000000000000000000000dEaD);
+        L2WethGateway(payable(l2WethGatewayLogic)).initialize(dead, dead, dead, dead);
 
         // init gateway
         L2WethGateway(payable(canonicalL2WethGateway)).initialize(

--- a/contracts/tokenbridge/arbitrum/L2AtomicTokenBridgeFactory.sol
+++ b/contracts/tokenbridge/arbitrum/L2AtomicTokenBridgeFactory.sol
@@ -25,6 +25,9 @@ import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
 contract L2AtomicTokenBridgeFactory {
     error L2AtomicTokenBridgeFactory_AlreadyExists();
 
+    // Dummy non-zero address which is provided to logic contracts initializers.
+    address private constant ADDRESS_DEAD = address(0x000000000000000000000000000000000000dEaD);
+
     function deployL2Contracts(
         L2RuntimeCode calldata l2Code,
         address l1Router,
@@ -119,9 +122,8 @@ contract L2AtomicTokenBridgeFactory {
             Create2.deploy(0, _getL2Salt(OrbitSalts.L2_ROUTER_LOGIC), _creationCodeFor(runtimeCode));
         ProxyAdmin(proxyAdmin).upgrade(ITransparentUpgradeableProxy(canonicalRouter), routerLogic);
 
-        // init logic contract with dummy values
-        address dead = address(0x000000000000000000000000000000000000dEaD);
-        L2GatewayRouter(routerLogic).initialize(dead, dead);
+        // init logic contract with dummy values.
+        L2GatewayRouter(routerLogic).initialize(ADDRESS_DEAD, ADDRESS_DEAD);
 
         // init
         L2GatewayRouter(canonicalRouter).initialize(l1Router, l2StandardGatewayCanonicalAddress);
@@ -152,8 +154,7 @@ contract L2AtomicTokenBridgeFactory {
         );
 
         // init logic contract with dummy values
-        address dead = address(0x000000000000000000000000000000000000dEaD);
-        L2ERC20Gateway(stdGatewayLogic).initialize(dead, dead, dead);
+        L2ERC20Gateway(stdGatewayLogic).initialize(ADDRESS_DEAD, ADDRESS_DEAD, ADDRESS_DEAD);
 
         // create beacon
         StandardArbERC20 standardArbERC20 = new StandardArbERC20{
@@ -198,8 +199,7 @@ contract L2AtomicTokenBridgeFactory {
         );
 
         // init logic contract with dummy values
-        address dead = address(0x000000000000000000000000000000000000dEaD);
-        L2CustomGateway(customGatewayLogicAddress).initialize(dead, dead);
+        L2CustomGateway(customGatewayLogicAddress).initialize(ADDRESS_DEAD, ADDRESS_DEAD);
 
         // init
         L2CustomGateway(canonicalCustomGateway).initialize(l1CustomGateway, router);
@@ -242,8 +242,9 @@ contract L2AtomicTokenBridgeFactory {
         );
 
         // init logic contract with dummy values
-        address dead = address(0x000000000000000000000000000000000000dEaD);
-        L2WethGateway(payable(l2WethGatewayLogic)).initialize(dead, dead, dead, dead);
+        L2WethGateway(payable(l2WethGatewayLogic)).initialize(
+            ADDRESS_DEAD, ADDRESS_DEAD, ADDRESS_DEAD, ADDRESS_DEAD
+        );
 
         // init gateway
         L2WethGateway(payable(canonicalL2WethGateway)).initialize(

--- a/contracts/tokenbridge/arbitrum/L2AtomicTokenBridgeFactory.sol
+++ b/contracts/tokenbridge/arbitrum/L2AtomicTokenBridgeFactory.sol
@@ -25,7 +25,10 @@ import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
 contract L2AtomicTokenBridgeFactory {
     error L2AtomicTokenBridgeFactory_AlreadyExists();
 
-    // Dummy non-zero address which is provided to logic contracts initializers.
+    // In order to avoid having uninitialized logic contracts, `initialize` function will be called
+    // on all logic contracts which don't have initializers disabled. This dummy non-zero address
+    // will be provided to those initializers, as values written to the logic contract's storage
+    // are not used.
     address private constant ADDRESS_DEAD = address(0x000000000000000000000000000000000000dEaD);
 
     function deployL2Contracts(
@@ -89,7 +92,8 @@ contract L2AtomicTokenBridgeFactory {
             proxyAdmin, _getL2Salt(OrbitSalts.L2_EXECUTOR), _getL2Salt(OrbitSalts.L2_EXECUTOR_LOGIC)
         );
 
-        // create UpgradeExecutor logic and upgrade to it
+        // Create UpgradeExecutor logic and upgrade to it.
+        // Note: UpgradeExecutor logic has initializer disabled so no need to call it.
         address upExecutorLogic = Create2.deploy(
             0, _getL2Salt(OrbitSalts.L2_EXECUTOR_LOGIC), _creationCodeFor(runtimeCode)
         );
@@ -218,7 +222,7 @@ contract L2AtomicTokenBridgeFactory {
             proxyAdmin, _getL2Salt(OrbitSalts.L2_WETH), _getL2Salt(OrbitSalts.L2_WETH_LOGIC)
         );
 
-        // create L2WETH logic and upgrade
+        // Create L2WETH logic and upgrade. Note: L2WETH logic has initializer disabled so no need to call it.
         address l2WethLogic = Create2.deploy(
             0, _getL2Salt(OrbitSalts.L2_WETH_LOGIC), _creationCodeFor(aeWethRuntimeCode)
         );

--- a/scripts/atomicTokenBridgeDeployer.ts
+++ b/scripts/atomicTokenBridgeDeployer.ts
@@ -42,6 +42,11 @@ import { RollupAdminLogic__factory } from '@arbitrum/sdk/dist/lib/abi/factories/
 import { ContractVerifier } from './contractVerifier'
 
 /**
+ * Dummy non-zero address which is provided to logic contracts initializers
+ */
+const ADDRESS_DEAD = '0x000000000000000000000000000000000000dEaD'
+
+/**
  * Use already deployed L1TokenBridgeCreator to create and init token bridge contracts.
  * Function first gets estimates for 2 retryable tickets - one for deploying L2 factory and
  * one for deploying L2 side of token bridge. Then it creates retryables, waits for
@@ -237,7 +242,7 @@ export const createTokenBridge = async (
     l2Weth,
     beaconProxyFactory,
     l2ProxyAdmin,
-    l2Multicall
+    l2Multicall,
   }
 }
 
@@ -304,40 +309,104 @@ export const deployL1TokenBridgeCreator = async (
     l1Deployer
   )
 
+  // initialize retryable sender logic contract
+  await (await retryableSenderLogic.initialize()).wait()
+
   /// init creator
   await (await l1TokenBridgeCreator.initialize(retryableSender.address)).wait()
 
-  /// deploy L1 logic contracts
+  /// deploy L1 logic contracts. Initialize them with dummy data
   const routerTemplate = await new L1GatewayRouter__factory(l1Deployer).deploy()
   await routerTemplate.deployed()
+  await (
+    await routerTemplate.initialize(
+      ADDRESS_DEAD,
+      ADDRESS_DEAD,
+      ADDRESS_DEAD,
+      ADDRESS_DEAD,
+      ADDRESS_DEAD
+    )
+  ).wait()
 
   const standardGatewayTemplate = await new L1ERC20Gateway__factory(
     l1Deployer
   ).deploy()
   await standardGatewayTemplate.deployed()
+  await (
+    await standardGatewayTemplate.initialize(
+      ADDRESS_DEAD,
+      ADDRESS_DEAD,
+      ADDRESS_DEAD,
+      ethers.utils.hexZeroPad('0x01', 32),
+      ADDRESS_DEAD
+    )
+  ).wait()
 
   const customGatewayTemplate = await new L1CustomGateway__factory(
     l1Deployer
   ).deploy()
   await customGatewayTemplate.deployed()
+  await (
+    await customGatewayTemplate.initialize(
+      ADDRESS_DEAD,
+      ADDRESS_DEAD,
+      ADDRESS_DEAD,
+      ADDRESS_DEAD
+    )
+  ).wait()
 
   const wethGatewayTemplate = await new L1WethGateway__factory(
     l1Deployer
   ).deploy()
   await wethGatewayTemplate.deployed()
+  await (
+    await wethGatewayTemplate.initialize(
+      ADDRESS_DEAD,
+      ADDRESS_DEAD,
+      ADDRESS_DEAD,
+      ADDRESS_DEAD,
+      ADDRESS_DEAD
+    )
+  ).wait()
 
   const feeTokenBasedRouterTemplate = await new L1OrbitGatewayRouter__factory(
     l1Deployer
   ).deploy()
   await feeTokenBasedRouterTemplate.deployed()
+  await (
+    await feeTokenBasedRouterTemplate.initialize(
+      ADDRESS_DEAD,
+      ADDRESS_DEAD,
+      ADDRESS_DEAD,
+      ADDRESS_DEAD,
+      ADDRESS_DEAD
+    )
+  ).wait()
 
   const feeTokenBasedStandardGatewayTemplate =
     await new L1OrbitERC20Gateway__factory(l1Deployer).deploy()
   await feeTokenBasedStandardGatewayTemplate.deployed()
+  await (
+    await feeTokenBasedStandardGatewayTemplate.initialize(
+      ADDRESS_DEAD,
+      ADDRESS_DEAD,
+      ADDRESS_DEAD,
+      ethers.utils.hexZeroPad('0x01', 32),
+      ADDRESS_DEAD
+    )
+  ).wait()
 
   const feeTokenBasedCustomGatewayTemplate =
     await new L1OrbitCustomGateway__factory(l1Deployer).deploy()
   await feeTokenBasedCustomGatewayTemplate.deployed()
+  await (
+    await feeTokenBasedCustomGatewayTemplate.initialize(
+      ADDRESS_DEAD,
+      ADDRESS_DEAD,
+      ADDRESS_DEAD,
+      ADDRESS_DEAD
+    )
+  ).wait()
 
   const upgradeExecutorFactory = new ethers.ContractFactory(
     UpgradeExecutorABI,
@@ -359,7 +428,7 @@ export const deployL1TokenBridgeCreator = async (
     upgradeExecutor: upgradeExecutor.address,
   }
 
-  /// deploy L2 contracts as placeholders on L1
+  /// deploy L2 contracts as placeholders on L1. Initialize them with dummy data
   const l2TokenBridgeFactoryOnL1 =
     await new L2AtomicTokenBridgeFactory__factory(l1Deployer).deploy()
   await l2TokenBridgeFactoryOnL1.deployed()
@@ -368,21 +437,42 @@ export const deployL1TokenBridgeCreator = async (
     l1Deployer
   ).deploy()
   await l2GatewayRouterOnL1.deployed()
+  await (
+    await l2GatewayRouterOnL1.initialize(ADDRESS_DEAD, ADDRESS_DEAD)
+  ).wait()
 
   const l2StandardGatewayAddressOnL1 = await new L2ERC20Gateway__factory(
     l1Deployer
   ).deploy()
   await l2StandardGatewayAddressOnL1.deployed()
+  await (
+    await l2StandardGatewayAddressOnL1.initialize(
+      ADDRESS_DEAD,
+      ADDRESS_DEAD,
+      ADDRESS_DEAD
+    )
+  ).wait()
 
   const l2CustomGatewayAddressOnL1 = await new L2CustomGateway__factory(
     l1Deployer
   ).deploy()
   await l2CustomGatewayAddressOnL1.deployed()
+  await (
+    await l2CustomGatewayAddressOnL1.initialize(ADDRESS_DEAD, ADDRESS_DEAD)
+  ).wait()
 
   const l2WethGatewayAddressOnL1 = await new L2WethGateway__factory(
     l1Deployer
   ).deploy()
   await l2WethGatewayAddressOnL1.deployed()
+  await (
+    await l2WethGatewayAddressOnL1.initialize(
+      ADDRESS_DEAD,
+      ADDRESS_DEAD,
+      ADDRESS_DEAD,
+      ADDRESS_DEAD
+    )
+  ).wait()
 
   const l2WethAddressOnL1 = await new AeWETH__factory(l1Deployer).deploy()
   await l2WethAddressOnL1.deployed()


### PR DESCRIPTION
Update deployer script which deploys token bridge creator so it initializes L1 and L2 logic contracts (templates) which are deployed to parent chain.

Also update L2AtomicTokenBridgfactory so it initializes logic contracts deployed to child chain when tkoen bridge is created. 