### PR TITLE
Register WETH gateway during local deployment

### DIFF
--- a/scripts/atomicTokenBridgeDeployer.ts
+++ b/scripts/atomicTokenBridgeDeployer.ts
@@ -26,6 +26,7 @@ import {
   IBridge__factory,
   Multicall2__factory,
   IInboxProxyAdmin__factory,
+  UpgradeExecutor__factory,
 } from '../build/types'
 import {
   abi as UpgradeExecutorABI,
@@ -41,6 +42,9 @@ import { exit } from 'process'
 import { getBaseFee } from '@arbitrum/sdk/dist/lib/utils/lib'
 import { RollupAdminLogic__factory } from '@arbitrum/sdk/dist/lib/abi/factories/RollupAdminLogic__factory'
 import { ContractVerifier } from './contractVerifier'
+import { OmitTyped } from '@arbitrum/sdk/dist/lib/utils/types'
+import { L1ToL2MessageGasParams } from '@arbitrum/sdk/dist/lib/message/L1ToL2MessageCreator'
+import { L1ContractCallTransactionReceipt } from '@arbitrum/sdk/dist/lib/message/L1Transaction'
 
 /**
  * Dummy non-zero address which is provided to logic contracts initializers
@@ -158,13 +162,11 @@ export const createTokenBridge = async (
     messageResults[1].status !== L1ToL2MessageStatus.REDEEMED
   ) {
     console.log(
-      `Retryable ticket (ID ${messages[0].retryableCreationId}) status: ${
-        L1ToL2MessageStatus[messageResults[0].status]
+      `Retryable ticket (ID ${messages[0].retryableCreationId}) status: ${L1ToL2MessageStatus[messageResults[0].status]
       }`
     )
     console.log(
-      `Retryable ticket (ID ${messages[1].retryableCreationId}) status: ${
-        L1ToL2MessageStatus[messageResults[1].status]
+      `Retryable ticket (ID ${messages[1].retryableCreationId}) status: ${L1ToL2MessageStatus[messageResults[1].status]
       }`
     )
     exit()
@@ -555,6 +557,62 @@ export const deployL1TokenBridgeCreator = async (
   return { l1TokenBridgeCreator, retryableSender }
 }
 
+export const registerGateway = async (
+  l1Executor: Signer,
+  l2Provider: ethers.providers.Provider,
+  upgradeExecutor: string,
+  gatewayRouter: string,
+  tokens: string[],
+  gateways: string[],
+) => {
+  const executorAddress = await l1Executor.getAddress()
+
+  const buildCall = (
+    params: OmitTyped<L1ToL2MessageGasParams, 'deposit'>
+  ) => {
+    const routerCalldata = L1GatewayRouter__factory.createInterface().encodeFunctionData(
+      'setGateways',
+      [
+        tokens,
+        gateways,
+        params.gasLimit,
+        params.maxFeePerGas,
+        params.maxSubmissionCost
+      ]
+    )
+    return {
+      data: UpgradeExecutor__factory.createInterface().encodeFunctionData("executeCall", [
+        gatewayRouter,
+        routerCalldata,
+      ]),
+      from: executorAddress,
+      value: params.gasLimit
+        .mul(params.maxFeePerGas)
+        .add(params.maxSubmissionCost),
+      to: upgradeExecutor,
+    }
+  }
+
+  const estimator = new L1ToL2MessageGasEstimator(l2Provider)
+  const txRequest = await estimator.populateFunctionParams(
+    buildCall,
+    l1Executor.provider!
+  )
+  
+  const receipt = new L1ContractCallTransactionReceipt(await (await l1Executor.sendTransaction(txRequest)).wait())
+
+  // wait for execution of ticket
+  const message = (await receipt.getL1ToL2Messages(l2Provider))[0]
+  const messageResult = await message.waitForStatus()
+  if (messageResult.status !== L1ToL2MessageStatus.REDEEMED) {
+    console.log(
+      `Retryable ticket (ID ${message.retryableCreationId}) status: ${L1ToL2MessageStatus[messageResult.status]
+      }`
+    )
+    exit()
+  }
+}
+
 export const getEstimateForDeployingFactory = async (
   l1Deployer: Signer,
   l2Provider: ethers.providers.Provider
@@ -612,7 +670,7 @@ const _getFeeToken = async (
       bridge,
       l1Provider
     ).nativeToken()
-  } catch {}
+  } catch { }
 
   return feeToken
 }

--- a/scripts/atomicTokenBridgeDeployer.ts
+++ b/scripts/atomicTokenBridgeDeployer.ts
@@ -599,7 +599,11 @@ export const registerGateway = async (
     l1Executor.provider!
   )
   
-  const receipt = new L1ContractCallTransactionReceipt(await (await l1Executor.sendTransaction(txRequest)).wait())
+  const receipt = new L1ContractCallTransactionReceipt(await (await l1Executor.sendTransaction({
+    to: txRequest.to,
+    data: txRequest.data,
+    value: txRequest.value,
+  })).wait())
 
   // wait for execution of ticket
   const message = (await receipt.getL1ToL2Messages(l2Provider))[0]

--- a/scripts/local-deployment/deployCreatorAndCreateTokenBridge.ts
+++ b/scripts/local-deployment/deployCreatorAndCreateTokenBridge.ts
@@ -115,14 +115,19 @@ export const setupTokenBridgeInLocalEnv = async () => {
   // prerequisite - deploy L1 creator and set templates
   console.log('Deploying L1TokenBridgeCreator')
 
-  const l1WethContract = await new TestWETH9__factory(parentDeployer).deploy(
-    'WETH',
-    'WETH'
-  )
-  await l1WethContract.deployed()
-
-  // a random address for l1Weth
-  const l1Weth = l1WethContract.address
+  let l1Weth = ''
+  if (process.env['L1_WETH_OVERRIDE'] !== undefined) {
+    l1Weth = process.env['L1_WETH_OVERRIDE'] as string
+  }
+  else {
+    const l1WethContract = await new TestWETH9__factory(parentDeployer).deploy(
+      'WETH',
+      'WETH'
+    )
+    await l1WethContract.deployed()
+    
+    l1Weth = l1WethContract.address
+  }
 
   //// run retryable estimate for deploying L2 factory
   const deployFactoryGasParams = await getEstimateForDeployingFactory(

--- a/scripts/local-deployment/deployCreatorAndCreateTokenBridge.ts
+++ b/scripts/local-deployment/deployCreatorAndCreateTokenBridge.ts
@@ -181,11 +181,11 @@ export const setupTokenBridgeInLocalEnv = async () => {
           ethers.utils.parseEther('.01')
         ]
       )
-    upExec.executeCall(
+    await (await upExec.executeCall(
       l1Deployment.router,
       routerCalldata,
       { value: '20000000000000000' }
-    )
+    )).wait()
   }
 
   const l2Network: L2Network = {

--- a/scripts/local-deployment/deployCreatorAndCreateTokenBridge.ts
+++ b/scripts/local-deployment/deployCreatorAndCreateTokenBridge.ts
@@ -37,6 +37,7 @@ const LOCALHOST_L3_OWNER = '0x863c904166E801527125D8672442D736194A3362'
  * @returns
  */
 export const setupTokenBridgeInLocalEnv = async () => {
+  throw new Error('Not implemented')
   // set RPCs either from env vars or use defaults
   let parentRpc = process.env['PARENT_RPC'] as string
   let childRpc = process.env['CHILD_RPC'] as string

--- a/scripts/local-deployment/deployCreatorAndCreateTokenBridge.ts
+++ b/scripts/local-deployment/deployCreatorAndCreateTokenBridge.ts
@@ -116,8 +116,8 @@ export const setupTokenBridgeInLocalEnv = async () => {
   console.log('Deploying L1TokenBridgeCreator')
 
   let l1Weth = ''
-  if (process.env['L1_WETH_OVERRIDE'] !== undefined && process.env['L1_WETH_OVERRIDE'] !== '') {
-    l1Weth = process.env['L1_WETH_OVERRIDE'] as string
+  if (process.env['PARENT_WETH_OVERRIDE'] !== undefined && process.env['PARENT_WETH_OVERRIDE'] !== '') {
+    l1Weth = process.env['PARENT_WETH_OVERRIDE'] as string
   }
   else {
     const l1WethContract = await new TestWETH9__factory(parentDeployer).deploy(

--- a/scripts/local-deployment/deployCreatorAndCreateTokenBridge.ts
+++ b/scripts/local-deployment/deployCreatorAndCreateTokenBridge.ts
@@ -114,7 +114,6 @@ export const setupTokenBridgeInLocalEnv = async () => {
 
   // prerequisite - deploy L1 creator and set templates
   console.log('Deploying L1TokenBridgeCreator')
-  console.log('----')
 
   const l1WethContract = await new TestWETH9__factory(parentDeployer).deploy(
     'WETH',

--- a/scripts/local-deployment/deployCreatorAndCreateTokenBridge.ts
+++ b/scripts/local-deployment/deployCreatorAndCreateTokenBridge.ts
@@ -116,7 +116,7 @@ export const setupTokenBridgeInLocalEnv = async () => {
   console.log('Deploying L1TokenBridgeCreator')
 
   let l1Weth = ''
-  if (process.env['L1_WETH_OVERRIDE'] !== undefined) {
+  if (process.env['L1_WETH_OVERRIDE'] !== undefined && process.env['L1_WETH_OVERRIDE'] !== '') {
     l1Weth = process.env['L1_WETH_OVERRIDE'] as string
   }
   else {

--- a/scripts/local-deployment/deployCreatorAndCreateTokenBridge.ts
+++ b/scripts/local-deployment/deployCreatorAndCreateTokenBridge.ts
@@ -22,7 +22,7 @@ import {
 
 const LOCALHOST_L2_RPC = 'http://localhost:8547'
 const LOCALHOST_L3_RPC = 'http://localhost:3347'
-const LOCALHOST_L3_OWNER = '0x863c904166E801527125D8672442D736194A3362'
+const LOCALHOST_L3_OWNER_KEY = '0xecdf21cb41c65afb51f91df408b7656e2c8739a5877f2814add0afd780cc210e'
 
 /**
  * Steps:
@@ -59,10 +59,11 @@ export const setupTokenBridgeInLocalEnv = async () => {
   }
 
   // set rollup owner either from env vars or use defaults
-  let rollupOwner = process.env['ROLLUP_OWNER'] as string
-  if (rollupOwner === undefined) {
-    rollupOwner = LOCALHOST_L3_OWNER
+  let rollupOwnerKey = process.env['ROLLUP_OWNER_KEY'] as string
+  if (rollupOwnerKey === undefined) {
+    rollupOwnerKey = LOCALHOST_L3_OWNER_KEY
   }
+  const rollupOwnerAddress = ethers.utils.computeAddress(rollupOwnerKey)
 
   // if no ROLLUP_ADDRESS is defined, it will be pulled from local container
   const rollupAddress = process.env['ROLLUP_ADDRESS'] as string
@@ -151,23 +152,20 @@ export const setupTokenBridgeInLocalEnv = async () => {
       childDeployer.provider!,
       l1TokenBridgeCreator,
       coreL2Network.ethBridge.rollup,
-      rollupOwner
+      rollupOwnerAddress
     )
 
   // register weth gateway if it exists
   if (
     l1Deployment.wethGateway !== ethers.constants.AddressZero
   ) {
-    const executorKey =
-      '0xcb5790da63720727af975f42c79f69918580209889225fa7128c92402a6d3a65' // todo: get from env
-
     const upExecAddress = await IOwnable__factory.connect(
       coreL2Network.ethBridge.rollup,
       parentDeployer
     ).owner()
 
     await registerGateway(
-      new Wallet(executorKey, parentDeployer.provider!),
+      new Wallet(rollupOwnerKey, parentDeployer.provider!),
       childDeployer.provider!,
       upExecAddress,
       l1Deployment.router,

--- a/scripts/local-deployment/deployCreatorAndCreateTokenBridge.ts
+++ b/scripts/local-deployment/deployCreatorAndCreateTokenBridge.ts
@@ -13,11 +13,7 @@ import {
 } from '../atomicTokenBridgeDeployer'
 import { l2Networks } from '@arbitrum/sdk/dist/lib/dataEntities/networks'
 import {
-  IERC20Bridge__factory,
-  IOwnable__factory,
-  L1GatewayRouter__factory,
-  TestWETH9__factory,
-  UpgradeExecutor__factory,
+  IOwnable__factory, TestWETH9__factory
 } from '../../build/types'
 
 const LOCALHOST_L2_RPC = 'http://localhost:8547'

--- a/scripts/local-deployment/deployCreatorAndCreateTokenBridge.ts
+++ b/scripts/local-deployment/deployCreatorAndCreateTokenBridge.ts
@@ -154,7 +154,7 @@ export const setupTokenBridgeInLocalEnv = async () => {
 
   // register weth gateway if not using custom fee token
   if (
-    l1Deployment.wethGateway !== ethers.constants.AddressZero
+    true || l1Deployment.wethGateway !== ethers.constants.AddressZero
   ) {
     const executorKey =
       '0xcb5790da63720727af975f42c79f69918580209889225fa7128c92402a6d3a65' // todo: get from env
@@ -178,11 +178,14 @@ export const setupTokenBridgeInLocalEnv = async () => {
           ethers.utils.parseEther('.01')
         ]
       )
-    await (await upExec.executeCall(
+    const rec = await (await upExec.executeCall(
       l1Deployment.router,
       routerCalldata,
       { value: '20000000000000000' }
     )).wait()
+    
+    console.log(rec.from, rec.to)
+    console.log(routerCalldata)
   }
 
   const l2Network: L2Network = {

--- a/scripts/local-deployment/deployCreatorAndCreateTokenBridge.ts
+++ b/scripts/local-deployment/deployCreatorAndCreateTokenBridge.ts
@@ -112,6 +112,7 @@ export const setupTokenBridgeInLocalEnv = async () => {
 
   // prerequisite - deploy L1 creator and set templates
   console.log('Deploying L1TokenBridgeCreator')
+  console.log('----')
 
   const l1WethContract = await new TestWETH9__factory(parentDeployer).deploy(
     'WETH',

--- a/scripts/local-deployment/deployCreatorAndCreateTokenBridge.ts
+++ b/scripts/local-deployment/deployCreatorAndCreateTokenBridge.ts
@@ -154,10 +154,7 @@ export const setupTokenBridgeInLocalEnv = async () => {
 
   // register weth gateway if not using custom fee token
   if (
-    (await getNativeToken(
-      coreL2Network.ethBridge.bridge,
-      parentDeployer.provider!
-    )) !== ethers.constants.AddressZero
+    l1Deployment.wethGateway === ethers.constants.AddressZero
   ) {
     const executorKey =
       '0xcb5790da63720727af975f42c79f69918580209889225fa7128c92402a6d3a65' // todo: get from env

--- a/scripts/local-deployment/deployCreatorAndCreateTokenBridge.ts
+++ b/scripts/local-deployment/deployCreatorAndCreateTokenBridge.ts
@@ -154,7 +154,7 @@ export const setupTokenBridgeInLocalEnv = async () => {
 
   // register weth gateway if not using custom fee token
   if (
-    l1Deployment.wethGateway === ethers.constants.AddressZero
+    l1Deployment.wethGateway !== ethers.constants.AddressZero
   ) {
     const executorKey =
       '0xcb5790da63720727af975f42c79f69918580209889225fa7128c92402a6d3a65' // todo: get from env

--- a/scripts/local-deployment/deployCreatorAndCreateTokenBridge.ts
+++ b/scripts/local-deployment/deployCreatorAndCreateTokenBridge.ts
@@ -11,6 +11,7 @@ import {
   getEstimateForDeployingFactory,
 } from '../atomicTokenBridgeDeployer'
 import { l2Networks } from '@arbitrum/sdk/dist/lib/dataEntities/networks'
+import { TestWETH9__factory } from '../../build/types'
 
 const LOCALHOST_L2_RPC = 'http://localhost:8547'
 const LOCALHOST_L3_RPC = 'http://localhost:3347'
@@ -105,8 +106,13 @@ export const setupTokenBridgeInLocalEnv = async () => {
 
   // prerequisite - deploy L1 creator and set templates
   console.log('Deploying L1TokenBridgeCreator')
+
+  const l1WethContract = await new TestWETH9__factory(parentDeployer).deploy("WETH", "WETH")
+  await l1WethContract.deployed()
+
+
   // a random address for l1Weth
-  const l1Weth = '0x05EcEffc7CBA4e43a410340E849052AD43815aCA'
+  const l1Weth = l1WethContract.address
 
   //// run retryable estimate for deploying L2 factory
   const deployFactoryGasParams = await getEstimateForDeployingFactory(

--- a/scripts/local-deployment/deployCreatorAndCreateTokenBridge.ts
+++ b/scripts/local-deployment/deployCreatorAndCreateTokenBridge.ts
@@ -217,18 +217,6 @@ export const setupTokenBridgeInLocalEnv = async () => {
   }
 }
 
-async function getNativeToken(
-  bridge: string,
-  parentProvider: ethers.providers.Provider
-) {
-  try {
-    const bridgeContract = IERC20Bridge__factory.connect(bridge, parentProvider)
-    return await bridgeContract.nativeToken()
-  } catch (e) {
-    return ethers.constants.AddressZero
-  }
-}
-
 export const getLocalNetworks = async (
   l1Url: string,
   l2Url: string,

--- a/scripts/local-deployment/deployCreatorAndCreateTokenBridge.ts
+++ b/scripts/local-deployment/deployCreatorAndCreateTokenBridge.ts
@@ -172,8 +172,8 @@ export const setupTokenBridgeInLocalEnv = async () => {
       L1GatewayRouter__factory.createInterface().encodeFunctionData(
         'setGateways',
         [
+          [l1Weth], 
           [l1Deployment.wethGateway], 
-          [l2Deployment.wethGateway], 
           10_000_000, 
           ethers.utils.parseUnits('1', 'gwei'), 
           ethers.utils.parseEther('.01')

--- a/scripts/local-deployment/deployCreatorAndCreateTokenBridge.ts
+++ b/scripts/local-deployment/deployCreatorAndCreateTokenBridge.ts
@@ -115,11 +115,8 @@ export const setupTokenBridgeInLocalEnv = async () => {
   // prerequisite - deploy L1 creator and set templates
   console.log('Deploying L1TokenBridgeCreator')
 
-  let l1Weth = ''
-  if (process.env['PARENT_WETH_OVERRIDE'] !== undefined && process.env['PARENT_WETH_OVERRIDE'] !== '') {
-    l1Weth = process.env['PARENT_WETH_OVERRIDE'] as string
-  }
-  else {
+  let l1Weth = process.env['PARENT_WETH_OVERRIDE']
+  if (l1Weth === undefined || l1Weth === '') {
     const l1WethContract = await new TestWETH9__factory(parentDeployer).deploy(
       'WETH',
       'WETH'

--- a/scripts/local-deployment/deployCreatorAndCreateTokenBridge.ts
+++ b/scripts/local-deployment/deployCreatorAndCreateTokenBridge.ts
@@ -37,7 +37,6 @@ const LOCALHOST_L3_OWNER = '0x863c904166E801527125D8672442D736194A3362'
  * @returns
  */
 export const setupTokenBridgeInLocalEnv = async () => {
-  throw new Error('Not implemented')
   // set RPCs either from env vars or use defaults
   let parentRpc = process.env['PARENT_RPC'] as string
   let childRpc = process.env['CHILD_RPC'] as string
@@ -156,7 +155,7 @@ export const setupTokenBridgeInLocalEnv = async () => {
 
   // register weth gateway if not using custom fee token
   if (
-    true || l1Deployment.wethGateway !== ethers.constants.AddressZero
+    l1Deployment.wethGateway !== ethers.constants.AddressZero
   ) {
     const executorKey =
       '0xcb5790da63720727af975f42c79f69918580209889225fa7128c92402a6d3a65' // todo: get from env


### PR DESCRIPTION
accompanies https://github.com/OffchainLabs/nitro-testnode/pull/30

* new `registerGateway` function
* the `ROLLUP_OWNER` env var passed to `deployCreatorAndCreateTokenBridge.ts::setupTokenBridgeInLocalEnv` is replaced by `ROLLUP_OWNER_KEY`

this should be squashed because of all the little '...' commits