### PR TITLE
Add note about token compatibility in the IArbToken interface

### DIFF
--- a/contracts/tokenbridge/arbitrum/IArbToken.sol
+++ b/contracts/tokenbridge/arbitrum/IArbToken.sol
@@ -19,6 +19,8 @@
 /**
  * @title Minimum expected interface for L2 token that interacts with the L2 token bridge (this is the interface necessary
  * for a custom token that interacts with the bridge, see TestArbCustomToken.sol for an example implementation).
+ * @dev For the token to be compatible out of the box with the tooling available (e.g., the Arbitrum bridge), it is
+ * recommended to keep the implementation of this interface as close as possible to the `TestArbCustomToken` example.
  */
 
 // solhint-disable-next-line compiler-version


### PR DESCRIPTION
This PR adds a note in the IArbToken interface to encourage users to keep an implementation as close as possible to the `TestArbCustomToken` example, since custom changes to the standard implementation of `bridgeMint` and `bridgeBurn` have caused issues with certain tokens not behaving as expected using some of the tooling available.

As an example, the bridge UI does not prompt an approval transaction when withdrawing a custom token, so tokens that customize `bridgeBurn` to check for allowance can't withdraw their tokens back to the parent chain.

This note has also been added to the docs here: https://docs.arbitrum.io/build-decentralized-apps/token-bridging/token-bridge-erc20#setting-up-your-token-with-the-generic-custom-gateway