### PR TITLE
Use new action version which enables customizing nitro-contracts branch

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -113,6 +113,7 @@ jobs:
           no-token-bridge: true
           no-l3-token-bridge: true
           nitro-contracts-branch: testnode-deploy
+          token-bridge-branch: develop
 
       - name: Setup node/yarn
         uses: actions/setup-node@v3
@@ -152,6 +153,7 @@ jobs:
           no-token-bridge: true
           no-l3-token-bridge: true
           nitro-contracts-branch: testnode-deploy
+          token-bridge-branch: develop
 
       - name: Setup node/yarn
         uses: actions/setup-node@v3

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -106,11 +106,13 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: OffchainLabs/actions/run-nitro-test-node@main
+      - uses: OffchainLabs/actions/run-nitro-test-node@customize-branches
         with:
+          nitro-testnode-ref: decouple-contracts
           l3-node: true 
           no-token-bridge: true
           no-l3-token-bridge: true
+          nitro-contracts-branch: testnode-deploy
 
       - name: Setup node/yarn
         uses: actions/setup-node@v3

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -142,12 +142,14 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: OffchainLabs/actions/run-nitro-test-node@main
+      - uses: OffchainLabs/actions/run-nitro-test-node@customize-branches
         with:
+          nitro-testnode-ref: decouple-contracts
           l3-node: true
           args: --l3-fee-token
           no-token-bridge: true
           no-l3-token-bridge: true
+          nitro-contracts-branch: testnode-deploy
 
       - name: Setup node/yarn
         uses: actions/setup-node@v3


### PR DESCRIPTION
Used just as PoC of new testnode action which enables specifying nitro-contracts and token-bridge-contracts versions 