### PR TITLE
nits on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ See the [developer documentation](https://developer.arbitrum.io/asset-bridging) 
 
 See security audit reports [here](./audits).
 
-This repository is offered under the Apache 2.0 license. See LICENSE for details.
+This repository is offered under the Apache 2.0 license. See [LICENSE](https://github.com/OffchainLabs/token-bridge-contracts/blob/main/LICENSE) for details.
 
 ## Deployment
 Check [this doc](./docs/deployment.md) for instructions on deployment and verification of token bridge.
 
 ## Contact
 
-Discord - [Arbitrum](https://discord.com/invite/5KE54JwyTs)
+Discord: [Arbitrum](https://discord.com/invite/5KE54JwyTs)
 
 Twitter: [Arbitrum](https://twitter.com/arbitrum)


### PR DESCRIPTION
add link to LICENSE, replaced dash with semicolon next to Discord