### PR TITLE
Ybb tob remediations

### DIFF
--- a/contracts/tokenbridge/ethereum/gateway/AbsYbbGateway.sol
+++ b/contracts/tokenbridge/ethereum/gateway/AbsYbbGateway.sol
@@ -76,6 +76,7 @@ abstract contract AbsYbbGateway is IYbbGateway {
         returns (uint256 amountReceived)
     {
         uint256 prevBalance = IERC20(_l1Token).balanceOf(address(this));
+        // slither-disable-next-line arbitrary-send-erc20
         IERC20(_l1Token).safeTransferFrom(_from, address(this), _amount);
         uint256 postBalance = IERC20(_l1Token).balanceOf(address(this));
         uint256 underlyingReceived = postBalance - prevBalance;

--- a/contracts/tokenbridge/ethereum/gateway/AbsYbbGateway.sol
+++ b/contracts/tokenbridge/ethereum/gateway/AbsYbbGateway.sol
@@ -6,12 +6,13 @@ import {IMasterVault} from "../../libraries/vault/IMasterVault.sol";
 import {IYbbGateway} from "./IYbbGateway.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {ERC165} from "../../libraries/ERC165.sol";
 
 /// @notice Abstract contract inherited by all YBB gateways.
 ///         Inherited directly by L1YbbCustomGateway and L1OrbitYbbCustomGateway, 
 ///         and inherited indirectly by L1YbbERC20Gateway and L1OrbitYbbERC20Gateway through AbsYbbERC20Gateway.
 ///         Provides shared logic for initialization and escrow handling.
-abstract contract AbsYbbGateway is IYbbGateway {
+abstract contract AbsYbbGateway is IYbbGateway, ERC165 {
     using SafeERC20 for IERC20;
 
     /// @notice Address of the MasterVaultFactory contract
@@ -60,6 +61,17 @@ abstract contract AbsYbbGateway is IYbbGateway {
             _data
         );
         require(receivedOnL2 >= minReceivedOnL2, "SLIPPAGE_EXCEEDED");
+    }
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override
+        returns (bool)
+    {
+        return interfaceId == this.outboundTransferCustomRefundWithSlippageTolerance.selector
+            || super.supportsInterface(interfaceId);
     }
 
     function inboundEscrowTransfer(address _l1Token, address _dest, uint256 _amount)

--- a/contracts/tokenbridge/ethereum/gateway/L1ArbitrumGateway.sol
+++ b/contracts/tokenbridge/ethereum/gateway/L1ArbitrumGateway.sol
@@ -280,13 +280,7 @@ abstract contract L1ArbitrumGateway is
                 bytes memory extraData;
                 uint256 _maxSubmissionCost;
                 uint256 tokenTotalFeeAmount;
-                if (super.isRouter(msg.sender)) {
-                    // router encoded
-                    (_from, extraData) = GatewayMessageHandler.parseFromRouterToGateway(_data);
-                } else {
-                    _from = msg.sender;
-                    extraData = _data;
-                }
+                (_from, extraData) = GatewayMessageHandler.parseFromRouterToGateway(_data);
                 // unpack user encoded data
                 (_maxSubmissionCost, extraData, tokenTotalFeeAmount) = _parseUserEncodedData(extraData);
 

--- a/contracts/tokenbridge/ethereum/gateway/L1ArbitrumGateway.sol
+++ b/contracts/tokenbridge/ethereum/gateway/L1ArbitrumGateway.sol
@@ -317,6 +317,7 @@ abstract contract L1ArbitrumGateway is
         // this method is virtual since different subclasses can handle escrow differently
         // user funds are escrowed on the gateway using this function
         uint256 prevBalance = IERC20(_l1Token).balanceOf(address(this));
+        // slither-disable-next-line arbitrary-send-erc20
         IERC20(_l1Token).safeTransferFrom(_from, address(this), _amount);
         uint256 postBalance = IERC20(_l1Token).balanceOf(address(this));
         return postBalance - prevBalance;

--- a/contracts/tokenbridge/ethereum/gateway/L1OrbitYbbCustomGateway.sol
+++ b/contracts/tokenbridge/ethereum/gateway/L1OrbitYbbCustomGateway.sol
@@ -57,4 +57,15 @@ contract L1OrbitYbbCustomGateway is L1OrbitCustomGateway, AbsYbbGateway {
             _data
         );
     }
+
+    // advertise the YBB slippage-tolerance entrypoint (ERC-165)
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        override(L1ArbitrumGateway)
+        returns (bool)
+    {
+        return interfaceId == this.outboundTransferCustomRefundWithSlippageTolerance.selector
+            || super.supportsInterface(interfaceId);
+    }
 }

--- a/contracts/tokenbridge/ethereum/gateway/L1OrbitYbbCustomGateway.sol
+++ b/contracts/tokenbridge/ethereum/gateway/L1OrbitYbbCustomGateway.sol
@@ -6,7 +6,6 @@ import {L1OrbitCustomGateway} from "./L1OrbitCustomGateway.sol";
 import {L1CustomGateway} from "./L1CustomGateway.sol";
 import {L1ArbitrumGateway} from "./L1ArbitrumGateway.sol";
 import {AbsYbbGateway} from "./AbsYbbGateway.sol";
-import {IERC20Bridge} from "../../libraries/IERC20Bridge.sol";
 
 /**
  * @title Layer 1 Gateway contract for bridging Custom ERC20s with YBB enabled in ERC20-based rollup
@@ -48,11 +47,6 @@ contract L1OrbitYbbCustomGateway is L1OrbitCustomGateway, AbsYbbGateway {
         uint256 _gasPriceBid,
         bytes calldata _data
     ) internal override(AbsYbbGateway, L1ArbitrumGateway) returns (bytes memory res, uint256 amountOnL2) {
-        require(msg.value == 0, "NO_VALUE");
-        require(
-            _l1Token != IERC20Bridge(address(getBridge(inbox))).nativeToken(),
-            "NOT_ALLOWED_TO_BRIDGE_FEE_TOKEN"
-        );
         return L1ArbitrumGateway._outboundTransferCustomRefund(
             _l1Token,
             _refundTo,

--- a/contracts/tokenbridge/ethereum/gateway/L1OrbitYbbCustomGateway.sol
+++ b/contracts/tokenbridge/ethereum/gateway/L1OrbitYbbCustomGateway.sol
@@ -6,6 +6,7 @@ import {L1OrbitCustomGateway} from "./L1OrbitCustomGateway.sol";
 import {L1CustomGateway} from "./L1CustomGateway.sol";
 import {L1ArbitrumGateway} from "./L1ArbitrumGateway.sol";
 import {AbsYbbGateway} from "./AbsYbbGateway.sol";
+import {IERC20Bridge} from "../../libraries/IERC20Bridge.sol";
 
 /**
  * @title Layer 1 Gateway contract for bridging Custom ERC20s with YBB enabled in ERC20-based rollup
@@ -47,6 +48,11 @@ contract L1OrbitYbbCustomGateway is L1OrbitCustomGateway, AbsYbbGateway {
         uint256 _gasPriceBid,
         bytes calldata _data
     ) internal override(AbsYbbGateway, L1ArbitrumGateway) returns (bytes memory res, uint256 amountOnL2) {
+        require(msg.value == 0, "NO_VALUE");
+        require(
+            _l1Token != IERC20Bridge(address(getBridge(inbox))).nativeToken(),
+            "NOT_ALLOWED_TO_BRIDGE_FEE_TOKEN"
+        );
         return L1ArbitrumGateway._outboundTransferCustomRefund(
             _l1Token,
             _refundTo,
@@ -58,14 +64,13 @@ contract L1OrbitYbbCustomGateway is L1OrbitCustomGateway, AbsYbbGateway {
         );
     }
 
-    // advertise the YBB slippage-tolerance entrypoint (ERC-165)
     function supportsInterface(bytes4 interfaceId)
         public
         view
-        override(L1ArbitrumGateway)
+        override(L1ArbitrumGateway, AbsYbbGateway)
         returns (bool)
     {
-        return interfaceId == this.outboundTransferCustomRefundWithSlippageTolerance.selector
-            || super.supportsInterface(interfaceId);
+        return L1ArbitrumGateway.supportsInterface(interfaceId)
+            || AbsYbbGateway.supportsInterface(interfaceId);
     }
 }

--- a/contracts/tokenbridge/ethereum/gateway/L1OrbitYbbERC20Gateway.sol
+++ b/contracts/tokenbridge/ethereum/gateway/L1OrbitYbbERC20Gateway.sol
@@ -82,4 +82,15 @@ contract L1OrbitYbbERC20Gateway is L1OrbitERC20Gateway, AbsYbbERC20Gateway {
             _data
         );
     }
+
+    // advertise the YBB slippage-tolerance entrypoint (ERC-165)
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        override(L1ArbitrumGateway)
+        returns (bool)
+    {
+        return interfaceId == this.outboundTransferCustomRefundWithSlippageTolerance.selector
+            || super.supportsInterface(interfaceId);
+    }
 }

--- a/contracts/tokenbridge/ethereum/gateway/L1OrbitYbbERC20Gateway.sol
+++ b/contracts/tokenbridge/ethereum/gateway/L1OrbitYbbERC20Gateway.sol
@@ -71,6 +71,7 @@ contract L1OrbitYbbERC20Gateway is L1OrbitERC20Gateway, AbsYbbERC20Gateway {
         uint256 _gasPriceBid,
         bytes calldata _data
     ) internal override(AbsYbbGateway, L1ArbitrumGateway) returns (bytes memory res, uint256 amountOnL2) {
+        require(msg.value == 0, "NO_VALUE");
         return L1ArbitrumGateway._outboundTransferCustomRefund(
             _l1Token,
             _refundTo,

--- a/contracts/tokenbridge/ethereum/gateway/L1OrbitYbbERC20Gateway.sol
+++ b/contracts/tokenbridge/ethereum/gateway/L1OrbitYbbERC20Gateway.sol
@@ -84,14 +84,13 @@ contract L1OrbitYbbERC20Gateway is L1OrbitERC20Gateway, AbsYbbERC20Gateway {
         );
     }
 
-    // advertise the YBB slippage-tolerance entrypoint (ERC-165)
     function supportsInterface(bytes4 interfaceId)
         public
         view
-        override(L1ArbitrumGateway)
+        override(L1ArbitrumGateway, AbsYbbGateway)
         returns (bool)
     {
-        return interfaceId == this.outboundTransferCustomRefundWithSlippageTolerance.selector
-            || super.supportsInterface(interfaceId);
+        return L1ArbitrumGateway.supportsInterface(interfaceId)
+            || AbsYbbGateway.supportsInterface(interfaceId);
     }
 }

--- a/contracts/tokenbridge/ethereum/gateway/L1OrbitYbbERC20Gateway.sol
+++ b/contracts/tokenbridge/ethereum/gateway/L1OrbitYbbERC20Gateway.sol
@@ -72,6 +72,7 @@ contract L1OrbitYbbERC20Gateway is L1OrbitERC20Gateway, AbsYbbERC20Gateway {
         bytes calldata _data
     ) internal override(AbsYbbGateway, L1ArbitrumGateway) returns (bytes memory res, uint256 amountOnL2) {
         require(msg.value == 0, "NO_VALUE");
+        require(_l1Token != _getNativeFeeToken(), "NOT_ALLOWED_TO_BRIDGE_FEE_TOKEN");
         return L1ArbitrumGateway._outboundTransferCustomRefund(
             _l1Token,
             _refundTo,

--- a/contracts/tokenbridge/ethereum/gateway/L1WethGateway.sol
+++ b/contracts/tokenbridge/ethereum/gateway/L1WethGateway.sol
@@ -78,6 +78,7 @@ contract L1WethGateway is L1ArbitrumExtendedGateway {
         address _from,
         uint256 _amount
     ) internal override returns (uint256) {
+        // slither-disable-next-line arbitrary-send-erc20
         IERC20(_l1Token).safeTransferFrom(_from, address(this), _amount);
         IWETH9(_l1Token).withdraw(_amount);
         // the weth token doesn't contain any special behaviour that changes the amount
@@ -90,6 +91,7 @@ contract L1WethGateway is L1ArbitrumExtendedGateway {
         address _dest,
         uint256 _amount
     ) internal override {
+        // slither-disable-next-line arbitrary-send-eth
         IWETH9(_l1Token).deposit{ value: _amount }();
         IERC20(_l1Token).safeTransfer(_dest, _amount);
     }

--- a/contracts/tokenbridge/ethereum/gateway/L1YbbCustomGateway.sol
+++ b/contracts/tokenbridge/ethereum/gateway/L1YbbCustomGateway.sol
@@ -56,4 +56,15 @@ contract L1YbbCustomGateway is L1CustomGateway, AbsYbbGateway {
             _data
         );
     }
+
+    // advertise the YBB slippage-tolerance entrypoint (ERC-165)
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        override(L1ArbitrumGateway)
+        returns (bool)
+    {
+        return interfaceId == this.outboundTransferCustomRefundWithSlippageTolerance.selector
+            || super.supportsInterface(interfaceId);
+    }
 }

--- a/contracts/tokenbridge/ethereum/gateway/L1YbbCustomGateway.sol
+++ b/contracts/tokenbridge/ethereum/gateway/L1YbbCustomGateway.sol
@@ -57,14 +57,13 @@ contract L1YbbCustomGateway is L1CustomGateway, AbsYbbGateway {
         );
     }
 
-    // advertise the YBB slippage-tolerance entrypoint (ERC-165)
     function supportsInterface(bytes4 interfaceId)
         public
         view
-        override(L1ArbitrumGateway)
+        override(L1ArbitrumGateway, AbsYbbGateway)
         returns (bool)
     {
-        return interfaceId == this.outboundTransferCustomRefundWithSlippageTolerance.selector
-            || super.supportsInterface(interfaceId);
+        return L1ArbitrumGateway.supportsInterface(interfaceId)
+            || AbsYbbGateway.supportsInterface(interfaceId);
     }
 }

--- a/contracts/tokenbridge/ethereum/gateway/L1YbbERC20Gateway.sol
+++ b/contracts/tokenbridge/ethereum/gateway/L1YbbERC20Gateway.sol
@@ -81,14 +81,13 @@ contract L1YbbERC20Gateway is L1ERC20Gateway, AbsYbbERC20Gateway {
         );
     }
 
-    // advertise the YBB slippage-tolerance entrypoint (ERC-165)
     function supportsInterface(bytes4 interfaceId)
         public
         view
-        override(L1ArbitrumGateway)
+        override(L1ArbitrumGateway, AbsYbbGateway)
         returns (bool)
     {
-        return interfaceId == this.outboundTransferCustomRefundWithSlippageTolerance.selector
-            || super.supportsInterface(interfaceId);
+        return L1ArbitrumGateway.supportsInterface(interfaceId)
+            || AbsYbbGateway.supportsInterface(interfaceId);
     }
 }

--- a/contracts/tokenbridge/ethereum/gateway/L1YbbERC20Gateway.sol
+++ b/contracts/tokenbridge/ethereum/gateway/L1YbbERC20Gateway.sol
@@ -80,4 +80,15 @@ contract L1YbbERC20Gateway is L1ERC20Gateway, AbsYbbERC20Gateway {
             _data
         );
     }
+
+    // advertise the YBB slippage-tolerance entrypoint (ERC-165)
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        override(L1ArbitrumGateway)
+        returns (bool)
+    {
+        return interfaceId == this.outboundTransferCustomRefundWithSlippageTolerance.selector
+            || super.supportsInterface(interfaceId);
+    }
 }

--- a/contracts/tokenbridge/libraries/vault/MasterVault.sol
+++ b/contracts/tokenbridge/libraries/vault/MasterVault.sol
@@ -491,7 +491,12 @@ contract MasterVault is
         uint256 totalIdle = asset.balanceOf(address(this));
 
         uint256 amountToTransfer = profit <= totalIdle ? profit : totalIdle;
+
+        // cap the subvault withdrawal at maxWithdraw so temporary illiquidity yields a partial
+        // distribution instead of reverting; the remainder stays as profit for a later call
+        uint256 maxWithdrawAmount = subVault.maxWithdraw(address(this));
         uint256 amountToWithdraw = profit - amountToTransfer;
+        if (amountToWithdraw > maxWithdrawAmount) amountToWithdraw = maxWithdrawAmount;
 
         if (amountToTransfer > 0) {
             asset.safeTransfer(beneficiary, amountToTransfer);

--- a/test-foundry/L1OrbitYbbCustomGateway.t.sol
+++ b/test-foundry/L1OrbitYbbCustomGateway.t.sol
@@ -175,38 +175,4 @@ contract L1OrbitYbbCustomGatewayTest is Test {
         );
         assertFalse(gateway.supportsInterface(bytes4(0)), "zero selector should not be supported");
     }
-
-    function test_outboundTransferCustomRefund_revert_NoValue() public {
-        vm.deal(address(router), 100 ether);
-        vm.prank(address(router));
-        vm.expectRevert("NO_VALUE");
-        gateway.outboundTransferCustomRefund{value: 1 ether}(
-            address(token), user, user, 100, maxGas, gasPriceBid, ""
-        );
-    }
-
-    function test_outboundTransferCustomRefundWithSlippageTolerance_revert_NoValue() public {
-        vm.deal(address(router), 100 ether);
-        vm.prank(address(router));
-        vm.expectRevert("NO_VALUE");
-        gateway.outboundTransferCustomRefundWithSlippageTolerance{value: 1 ether}(
-            address(token), user, user, 100, maxGas, gasPriceBid, "", 0
-        );
-    }
-
-    function test_outboundTransfer_revert_NotAllowedToBridgeFeeToken() public {
-        vm.prank(address(router));
-        vm.expectRevert("NOT_ALLOWED_TO_BRIDGE_FEE_TOKEN");
-        gateway.outboundTransfer(address(nativeToken), user, 100, maxGas, gasPriceBid, "");
-    }
-
-    function test_outboundTransferCustomRefundWithSlippageTolerance_revert_NotAllowedToBridgeFeeToken()
-        public
-    {
-        vm.prank(address(router));
-        vm.expectRevert("NOT_ALLOWED_TO_BRIDGE_FEE_TOKEN");
-        gateway.outboundTransferCustomRefundWithSlippageTolerance(
-            address(nativeToken), user, user, 100, maxGas, gasPriceBid, "", 0
-        );
-    }
 }

--- a/test-foundry/L1OrbitYbbCustomGateway.t.sol
+++ b/test-foundry/L1OrbitYbbCustomGateway.t.sol
@@ -175,4 +175,38 @@ contract L1OrbitYbbCustomGatewayTest is Test {
         );
         assertFalse(gateway.supportsInterface(bytes4(0)), "zero selector should not be supported");
     }
+
+    function test_outboundTransferCustomRefund_revert_NoValue() public {
+        vm.deal(address(router), 100 ether);
+        vm.prank(address(router));
+        vm.expectRevert("NO_VALUE");
+        gateway.outboundTransferCustomRefund{value: 1 ether}(
+            address(token), user, user, 100, maxGas, gasPriceBid, ""
+        );
+    }
+
+    function test_outboundTransferCustomRefundWithSlippageTolerance_revert_NoValue() public {
+        vm.deal(address(router), 100 ether);
+        vm.prank(address(router));
+        vm.expectRevert("NO_VALUE");
+        gateway.outboundTransferCustomRefundWithSlippageTolerance{value: 1 ether}(
+            address(token), user, user, 100, maxGas, gasPriceBid, "", 0
+        );
+    }
+
+    function test_outboundTransfer_revert_NotAllowedToBridgeFeeToken() public {
+        vm.prank(address(router));
+        vm.expectRevert("NOT_ALLOWED_TO_BRIDGE_FEE_TOKEN");
+        gateway.outboundTransfer(address(nativeToken), user, 100, maxGas, gasPriceBid, "");
+    }
+
+    function test_outboundTransferCustomRefundWithSlippageTolerance_revert_NotAllowedToBridgeFeeToken()
+        public
+    {
+        vm.prank(address(router));
+        vm.expectRevert("NOT_ALLOWED_TO_BRIDGE_FEE_TOKEN");
+        gateway.outboundTransferCustomRefundWithSlippageTolerance(
+            address(nativeToken), user, user, 100, maxGas, gasPriceBid, "", 0
+        );
+    }
 }

--- a/test-foundry/L1OrbitYbbCustomGateway.t.sol
+++ b/test-foundry/L1OrbitYbbCustomGateway.t.sol
@@ -161,4 +161,18 @@ contract L1OrbitYbbCustomGatewayTest is Test {
             abi.encode(maxSubmissionCost, callHookData, nativeTokenTotalFee);
         return abi.encode(user, userEncodedData);
     }
+
+    function test_supportsInterface_slippageTolerance() public {
+        assertTrue(
+            gateway.supportsInterface(
+                gateway.outboundTransferCustomRefundWithSlippageTolerance.selector
+            ),
+            "slippage-tolerance selector should be supported"
+        );
+        assertTrue(
+            gateway.supportsInterface(gateway.outboundTransferCustomRefund.selector),
+            "outboundTransferCustomRefund selector should still be supported"
+        );
+        assertFalse(gateway.supportsInterface(bytes4(0)), "zero selector should not be supported");
+    }
 }

--- a/test-foundry/L1OrbitYbbERC20Gateway.t.sol
+++ b/test-foundry/L1OrbitYbbERC20Gateway.t.sol
@@ -120,6 +120,16 @@ contract L1OrbitYbbERC20GatewayTest is Test {
         gateway.outboundTransfer(address(nativeToken), user, 100, maxGas, gasPriceBid, "");
     }
 
+    function test_outboundTransferCustomRefundWithSlippageTolerance_revert_NotAllowedToBridgeFeeToken()
+        public
+    {
+        vm.prank(address(router));
+        vm.expectRevert("NOT_ALLOWED_TO_BRIDGE_FEE_TOKEN");
+        gateway.outboundTransferCustomRefundWithSlippageTolerance(
+            address(nativeToken), user, user, 100, maxGas, gasPriceBid, "", 0
+        );
+    }
+
     function test_getOutboundCalldata_reportsVaultDecimals() public {
         _depositToCreateVault();
 

--- a/test-foundry/L1OrbitYbbERC20Gateway.t.sol
+++ b/test-foundry/L1OrbitYbbERC20Gateway.t.sol
@@ -105,6 +105,15 @@ contract L1OrbitYbbERC20GatewayTest is Test {
         );
     }
 
+    function test_outboundTransferCustomRefundWithSlippageTolerance_revert_NoValue() public {
+        vm.deal(address(router), 100 ether);
+        vm.prank(address(router));
+        vm.expectRevert("NO_VALUE");
+        gateway.outboundTransferCustomRefundWithSlippageTolerance{value: 1 ether}(
+            address(token), user, user, 100, maxGas, gasPriceBid, "", 0
+        );
+    }
+
     function test_outboundTransfer_revert_NotAllowedToBridgeFeeToken() public {
         vm.prank(address(router));
         vm.expectRevert("NOT_ALLOWED_TO_BRIDGE_FEE_TOKEN");

--- a/test-foundry/L1OrbitYbbERC20Gateway.t.sol
+++ b/test-foundry/L1OrbitYbbERC20Gateway.t.sol
@@ -280,4 +280,18 @@ contract L1OrbitYbbERC20GatewayTest is Test {
             abi.encode(maxSubmissionCost, callHookData, nativeTokenTotalFee);
         return abi.encode(user, userEncodedData);
     }
+
+    function test_supportsInterface_slippageTolerance() public {
+        assertTrue(
+            gateway.supportsInterface(
+                gateway.outboundTransferCustomRefundWithSlippageTolerance.selector
+            ),
+            "slippage-tolerance selector should be supported"
+        );
+        assertTrue(
+            gateway.supportsInterface(gateway.outboundTransferCustomRefund.selector),
+            "outboundTransferCustomRefund selector should still be supported"
+        );
+        assertFalse(gateway.supportsInterface(bytes4(0)), "zero selector should not be supported");
+    }
 }

--- a/test-foundry/L1YbbCustomGateway.t.sol
+++ b/test-foundry/L1YbbCustomGateway.t.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+import {L1YbbCustomGateway} from "contracts/tokenbridge/ethereum/gateway/L1YbbCustomGateway.sol";
+import {L1GatewayRouter} from "contracts/tokenbridge/ethereum/gateway/L1GatewayRouter.sol";
+import {MasterVault} from "contracts/tokenbridge/libraries/vault/MasterVault.sol";
+import {MasterVaultFactory} from "contracts/tokenbridge/libraries/vault/MasterVaultFactory.sol";
+import {IGatewayRouter} from "contracts/tokenbridge/libraries/gateway/IGatewayRouter.sol";
+import {InboxMock} from "contracts/tokenbridge/test/InboxMock.sol";
+
+contract L1YbbCustomGatewayTest is Test {
+    L1YbbCustomGateway public gateway;
+    L1GatewayRouter public router;
+    MasterVaultFactory public factory;
+    InboxMock public inbox;
+
+    address public l2Gateway = makeAddr("l2Gateway");
+    address public l2Router = makeAddr("l2Router");
+    address public owner = makeAddr("owner");
+
+    function setUp() public {
+        inbox = new InboxMock();
+        router = new L1GatewayRouter();
+        MasterVault masterVaultImpl = new MasterVault();
+        factory = new MasterVaultFactory();
+
+        gateway = new L1YbbCustomGateway();
+        gateway.initialize(l2Gateway, address(router), address(inbox), owner, address(factory));
+
+        router.initialize(address(this), address(gateway), address(0), l2Router, address(inbox));
+
+        factory.initialize(address(masterVaultImpl), address(this), IGatewayRouter(address(router)));
+    }
+
+    function test_supportsInterface_slippageTolerance() public {
+        assertTrue(
+            gateway.supportsInterface(
+                gateway.outboundTransferCustomRefundWithSlippageTolerance.selector
+            ),
+            "slippage-tolerance selector should be supported"
+        );
+        assertTrue(
+            gateway.supportsInterface(gateway.outboundTransferCustomRefund.selector),
+            "outboundTransferCustomRefund selector should still be supported"
+        );
+        assertFalse(gateway.supportsInterface(bytes4(0)), "zero selector should not be supported");
+    }
+}

--- a/test-foundry/L1YbbERC20Gateway.t.sol
+++ b/test-foundry/L1YbbERC20Gateway.t.sol
@@ -374,4 +374,18 @@ contract L1YbbERC20GatewayTest is Test {
             "Parse failure should leave original bytes untouched"
         );
     }
+
+    function test_supportsInterface_slippageTolerance() public {
+        assertTrue(
+            gateway.supportsInterface(
+                gateway.outboundTransferCustomRefundWithSlippageTolerance.selector
+            ),
+            "slippage-tolerance selector should be supported"
+        );
+        assertTrue(
+            gateway.supportsInterface(gateway.outboundTransferCustomRefund.selector),
+            "outboundTransferCustomRefund selector should still be supported"
+        );
+        assertFalse(gateway.supportsInterface(bytes4(0)), "zero selector should not be supported");
+    }
 }

--- a/test-foundry/libraries/vault/mutation/MasterVaultFees.t.sol
+++ b/test-foundry/libraries/vault/mutation/MasterVaultFees.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.0;
 import {MasterVaultCoreTest} from "../MasterVaultCore.t.sol";
 import {MasterVault} from "../../../../contracts/tokenbridge/libraries/vault/MasterVault.sol";
 import {TestERC20} from "../../../../contracts/tokenbridge/test/TestERC20.sol";
+import {FuzzSubVault} from "../../../../contracts/tokenbridge/test/FuzzSubVault.sol";
 import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {Vm} from "forge-std/Test.sol";
@@ -156,5 +157,31 @@ contract MasterVaultFeesTest is MasterVaultCoreTest {
         uint256 subVaultBalAfter = token.balanceOf(address(vault.subVault()));
         assertEq(token.balanceOf(beneficiaryAddr), profit, "beneficiary should receive all profit");
         assertTrue(subVaultBalBefore > subVaultBalAfter, "subvault balance should decrease");
+    }
+
+    function test_distributePerformanceFee_partialWhenSubVaultIlliquid() public {
+        // illiquid subvault must yield a partial distribution, not revert the whole call
+        FuzzSubVault fuzzSv = new FuzzSubVault(IERC20(address(token)), "Fuzz", "FZ");
+        vault.setSubVaultWhitelist(address(fuzzSv), true);
+        vault.setSubVault(IERC4626(address(fuzzSv)));
+
+        _setupWithAllocation(100e18, 1e18); // 100% to subvault, idle = 0
+        assertEq(token.balanceOf(address(vault)), 0, "idle should be 0");
+
+        token.mintAmount(10e18);
+        token.transfer(address(fuzzSv), 10e18); // profit accrues in the subvault
+        uint256 profitBefore = vault.totalProfit();
+        assertGt(profitBefore, 0, "should have profit");
+
+        uint256 liquidCap = 4e18;
+        assertLt(liquidCap, profitBefore, "cap must be below profit");
+        fuzzSv.setMaxWithdrawLimit(liquidCap);
+
+        // pre-fix: reverts ("FuzzSubVault: withdraw exceeds max"); post-fix: partial distribution
+        vm.prank(keeper);
+        vault.distributePerformanceFee();
+
+        assertEq(token.balanceOf(beneficiaryAddr), liquidCap, "beneficiary gets capped amount");
+        assertGt(vault.totalProfit(), 0, "remainder stays as profit");
     }
 }


### PR DESCRIPTION
 Selector advertised on the YBB gateways, not `L1ArbitrumGateway`, since the slippage entry point only exists on YBB subclasses. putting it in the shared base would make non-YBB gateways falsely report ERC-165 support for a function they lack.

